### PR TITLE
Ajuste de middlewares de grupos.

### DIFF
--- a/src/presentation/controllers/company/company.controller.ts
+++ b/src/presentation/controllers/company/company.controller.ts
@@ -18,11 +18,7 @@ export class CompanyController {
 
   public create = async (req: Request, res: Response) => {
     const dto = req.body as CreateCompanyDto;
-    // req.assignGroupId comes from assignGroup middleware
-    const company = await this.createCompanyUseCase.execute({
-      ...dto,
-      groupId: req.assignGroupId!,
-    });
+    const company = await this.createCompanyUseCase.execute(dto);
 
     res.status(201).json({
       success: true,
@@ -34,14 +30,9 @@ export class CompanyController {
     const { id } = req.params;
     const dto = req.body as UpdateCompanyDto;
 
-    // Si changeGroup middleware puso algo en assignGroupId, lo usamos.
-    // De lo contrario, usamos lo que venga en el dto (que podría ser undefined si no se quiere cambiar)
-    const groupId = req.assignGroupId !== undefined ? req.assignGroupId : dto.groupId;
-
     const company = await this.updateCompanyUseCase.execute({
       ...dto,
       id,
-      groupId,
     });
 
     res.status(200).json({

--- a/src/presentation/dto/company/create-company.dto.ts
+++ b/src/presentation/dto/company/create-company.dto.ts
@@ -4,5 +4,5 @@ export interface CreateCompanyDto {
   address?: string;
   phone?: string;
   email?: string;
-  groupId?: number; // Optional in DTO because assignGroup middleware can set it
+  groupId: number;
 }

--- a/src/shared/middleware/group.middleware.ts
+++ b/src/shared/middleware/group.middleware.ts
@@ -2,80 +2,78 @@ import { Request, Response, NextFunction } from 'express';
 import { User } from '@domains/user/entities/user.entity';
 import { ForbiddenError, UnauthorizedError, ValidationError } from '@shared/domain/errors';
 
-// Extiende el tipo Request para incluir la propiedad assignGroupId
-declare module 'express-serve-static-core' {
-  interface Request {
-    assignGroupId?: number;
-  }
-}
-
-type GroupFieldSelector = (body: any) => any;
+type Body = Request['body'];
+type GroupIdHandlers = {
+  get?: (body: Body) => any,
+  set?: (body: Body, groupId?: number) => void,
+};
 
 /**
  * Middleware para asignar un ID de grupo al request basado en el grupo seleccionado del usuario logueado,
  * o desde el body de la request si el usuario tiene el permiso admin:groups.
+ * El valor se guarda en el body de la request (default: body.groupId).
  *
- * @param fieldGetter - Función para extraer el ID del grupo del body de la request (default: body.groupId)
+ * @param handlers - Objeto con las funciones para extraer y guardar el ID del grupo del body.
  */
-export function assignGroup(fieldGetter: GroupFieldSelector = (body) => body.groupId) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const user = req.user as User;
-    if (!user) {
-      throw new UnauthorizedError();
-    }
-    const dispatchGroupId = dispatcher(req, next);
+export const assignGroup = (handlers?: GroupIdHandlers) => (req: Request, _res: Response, next: NextFunction) => {
+  const [ user, groupId, setGroupId ] = init(req, handlers);
 
-    if (user.can('admin:groups')) {
-      // Obtiene el grupo del body de la request.
-      const bodyGroupId = parseId(fieldGetter(req.body));
-      if (bodyGroupId) return dispatchGroupId(bodyGroupId);
-    }
+  if (user.can('admin:groups')) {
+    // Obtiene el grupo del body de la request.
+    if (groupId) return setGroupId(groupId), next();
+  }
 
-    // Si el usuario tiene grupo asignado, lo almacena y continua.
-    const groupId = parseId(req.groupId);
-    if (groupId) return dispatchGroupId(groupId);
+  // Si el usuario tiene grupo asignado, lo almacena y continua.
+  const userGroupId = parseId(req.groupId);
+  if (userGroupId) return setGroupId(userGroupId), next();
 
-    // Si no tiene el permiso admin:groups, devuelve error de autorización.
-    if (!user.can('admin:groups')) {
-      throw new ForbiddenError('Forbidden: You can\'t proceed without a group assigned.');
-    }
-
-    // Devuelve error de validación, ID de grupo requerido.
+  // Si tiene el permiso admin:groups, devuelve error de validación.
+  if (user.can('admin:groups')) {
     throw new ValidationError('El ID del grupo es requerido');
-  };
-}
+  }
+
+  // Si no tiene el permiso admin:groups, devuelve error de autorización.
+  throw new ForbiddenError('Prohibido: No puedes continuar sin un grupo asignado.');
+};
 
 /**
  * Middleware para cambiar el ID de grupo si el usuario tiene los permisos user:change:group o admin:groups.
  *
- * @param fieldGetter - Función para extraer el ID del grupo del body de la request (default: body.groupId)
+ * @param handlers - Objeto con las funciones para extraer, guardar y remover el ID del grupo del body de la request (default: body.groupId)
  */
-export function changeGroup(fieldGetter: GroupFieldSelector = (body) => body.groupId) {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const user = req.user as User;
-    if (!user) {
-      throw new UnauthorizedError();
-    }
+export const changeGroup = (handlers?: GroupIdHandlers & {
+  unset?: (body: Body) => void,
+}) => (req: Request, _res: Response, next: NextFunction) => {
+  const [ user, groupId, setGroupId ] = init(req, handlers);
+  const unsetGroupId = handlers?.unset ?? ((body: Body) => { delete body.groupId; });
 
-    // Busca el grupo en el body de la request.
-    const id = parseId(fieldGetter(req.body));
-    // Si no existe, se mantiene el grupo actual.
-    if (!id) return next();
+  // Si no existe, se mantiene el grupo actual.
+  if (!groupId) return unsetGroupId(req.body), next();
 
-    // Usuarios con los permisos user:change:group o admin:groups pueden cambiar el grupo.
-    if (user.can(['user:change:group', 'admin:groups'])) {
-      return dispatcher(req, next)(id);
-    }
+  // Usuarios con los permisos user:change:group o admin:groups pueden cambiar el grupo.
+  if (user.can(['user:change:group', 'admin:groups'])) {
+    return setGroupId(groupId), next();
+  }
 
-    // Si no tienen los permisos, lanzamos error de autorización.
-    throw new ForbiddenError('Forbidden: You can\'t change the group.');
-  };
-}
-
-const dispatcher = (req: Request, next: NextFunction) => (groupId: number) => {
-  req.assignGroupId = groupId;
-  return next();
+  // Si no tienen los permisos, lanzamos error de autorización.
+  throw new ForbiddenError('Prohibido: No puedes cambiar el grupo.');
 };
+
+function init(req: Request, handlers?: GroupIdHandlers) {
+  const user = req.user as User;
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+
+  req.body = req.body || {};
+  const getter = handlers?.get ?? ((body: Body) => body.groupId);
+  const setter = handlers?.set ?? ((body: Body, groupId?: number) => { body.groupId = groupId; });
+  return [
+    user,
+    parseId(getter(req.body)),
+    (groupId?: number) => setter(req.body, groupId),
+  ] as const;
+}
 
 function parseId(value: any): number | null {
   if (!value) return null;


### PR DESCRIPTION
- En lugar de almacenar el grupo en el request general, se almacena en el body (que es la data enviada por el usuario.
- De ser necesario se puede modificar la forma en que se lee y/o guarda el id del grupo en el body.