### PR TITLE
Relaciones de group con contract, document y colaborator.

### DIFF
--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -456,7 +456,7 @@ export class DependencyContainer {
 
 
     // Initialize Document use cases
-    this.createDocumentUseCase = new CreateDocumentUseCase(this.documentRepository, this.documentHistoryRepository);
+    this.createDocumentUseCase = new CreateDocumentUseCase(this.documentRepository, this.documentHistoryRepository, this.groupRepository);
     this.getDocumentByIdUseCase = new GetDocumentByIdUseCase(this.documentRepository);
     this.getAllDocumentsUseCase = new GetAllDocumentsUseCase(this.documentRepository);
     this.getDocumentsByContractIdUseCase = new GetDocumentsByContractIdUseCase(this.documentRepository);
@@ -464,7 +464,7 @@ export class DependencyContainer {
     this.getDocumentsByColaboratorIdUseCase = new GetDocumentsByColaboratorIdUseCase(this.documentRepository);
     this.getExpiredDocumentsUseCase = new GetExpiredDocumentsUseCase(this.documentRepository);
     this.getExpiringDocumentsUseCase = new GetExpiringDocumentsUseCase(this.documentRepository);
-    this.updateDocumentUseCase = new UpdateDocumentUseCase(this.documentRepository, this.documentHistoryRepository);
+    this.updateDocumentUseCase = new UpdateDocumentUseCase(this.documentRepository, this.documentHistoryRepository, this.groupRepository);
     this.deleteDocumentUseCase = new DeleteDocumentUseCase(this.documentRepository);
     this.sendToReviewDocumentUseCase = new SendToReviewDocumentUseCase(this.documentRepository, this.documentHistoryRepository);
     this.approveDocumentUseCase = new ApproveDocumentUseCase(this.documentRepository, this.documentHistoryRepository);
@@ -476,6 +476,7 @@ export class DependencyContainer {
       this.documentRepository,
       this.documentHistoryRepository,
       this.contractRepository,
+      this.colaboratorRepository,
     );
 
 
@@ -698,6 +699,7 @@ export class DependencyContainer {
       this.documentRepository,
       this.documentHistoryRepository,
       this.contractRepository,
+      this.colaboratorRepository,
     );
 
     this.familyController = new FamilyController(

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -523,9 +523,9 @@ export class DependencyContainer {
     this.getContractColaboratorsUseCase = new GetContractColaboratorsUseCase(this.contractRepository);
 
     // Initialize Colaborator use cases
-    this.createColaboratorUseCase = new CreateColaboratorUseCase(this.colaboratorRepository);
+    this.createColaboratorUseCase = new CreateColaboratorUseCase(this.colaboratorRepository, this.groupRepository);
     this.getColaboratorUseCase = new GetColaboratorUseCase(this.colaboratorRepository);
-    this.updateColaboratorUseCase = new UpdateColaboratorUseCase(this.colaboratorRepository);
+    this.updateColaboratorUseCase = new UpdateColaboratorUseCase(this.colaboratorRepository, this.groupRepository);
     this.deleteColaboratorUseCase = new DeleteColaboratorUseCase(this.colaboratorRepository);
     this.updateColaboratorContractsUseCase = new UpdateColaboratorContractsUseCase(this.colaboratorRepository);
     this.getContractsByColaboratorUseCase = new GetContractsByColaboratorUseCase(this.contractRepository);

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -481,7 +481,7 @@ export class DependencyContainer {
 
 
     // Initialize Contract use cases
-    this.createContractUseCase = new CreateContractUseCase(this.contractRepository);
+    this.createContractUseCase = new CreateContractUseCase(this.contractRepository, this.groupRepository);
     this.getContractByIdUseCase = new GetContractByIdUseCase(this.contractRepository);
     this.getAllContractsUseCase = new GetAllContractsUseCase(this.contractRepository);
     this.getContractsByRutSociedadUseCase = new GetContractsByRutSociedadUseCase(this.contractRepository);
@@ -493,7 +493,7 @@ export class DependencyContainer {
     this.getActiveContractsUseCase = new GetActiveContractsUseCase(this.contractRepository);
     this.getExpiredContractsUseCase = new GetExpiredContractsUseCase(this.contractRepository);
     this.getContractsEndingBeforeUseCase = new GetContractsEndingBeforeUseCase(this.contractRepository);
-    this.updateContractUseCase = new UpdateContractUseCase(this.contractRepository);
+    this.updateContractUseCase = new UpdateContractUseCase(this.contractRepository, this.groupRepository);
     this.activateContractUseCase = new ActivateContractUseCase(this.contractRepository);
     this.suspendContractUseCase = new SuspendContractUseCase(this.contractRepository);
     this.terminateContractUseCase = new TerminateContractUseCase(this.contractRepository);

--- a/src/domains/colaborators/entities/colaborator.entity.ts
+++ b/src/domains/colaborators/entities/colaborator.entity.ts
@@ -31,6 +31,7 @@ export interface ColaboratorProps {
   telefonoEmergencia?: string;
   profesion: string;
   cargo: string;
+  groupId: number;
   status?: ColaboratorStatus;
   createdAt?: Date;
   updatedAt?: Date;
@@ -63,6 +64,7 @@ export interface ColaboratorJson {
   telefonoEmergencia?: string;
   profesion: string;
   cargo: string;
+  groupId: number;
   status: ColaboratorStatus;
   isActive: boolean;
   contractIds?: string[];
@@ -95,6 +97,7 @@ export class Colaborator extends BaseEntity {
     private _telefonoEmergencia: string | undefined,
     private _profesion: string,
     private _cargo: string,
+    private _groupId: number,
     private _status: ColaboratorStatus,
     public createdAt: Date,
     public updatedAt: Date,
@@ -136,6 +139,7 @@ export class Colaborator extends BaseEntity {
       props.telefonoEmergencia?.trim(),
       props.profesion.trim(),
       props.cargo.trim(),
+      props.groupId,
       status,
       props.createdAt || new Date(),
       props.updatedAt || new Date(),
@@ -170,6 +174,7 @@ export class Colaborator extends BaseEntity {
       props.telefonoEmergencia,
       props.profesion,
       props.cargo,
+      props.groupId,
       status,
       props.createdAt! instanceof Date ? props.createdAt! : new Date(props.createdAt!),
       props.updatedAt! instanceof Date ? props.updatedAt! : new Date(props.updatedAt!),
@@ -220,6 +225,9 @@ export class Colaborator extends BaseEntity {
     }
     if (!props.cargo?.trim()) {
       throw new ValidationError('Cargo is required', 'cargo');
+    }
+    if (!props.groupId) {
+      throw new ValidationError('Group ID is required', 'groupId');
     }
   }
 
@@ -355,6 +363,10 @@ export class Colaborator extends BaseEntity {
     return this._status;
   }
 
+  public get groupId(): number {
+    return this._groupId;
+  }
+
   // Business methods
   public getNombreCompleto(): string {
     if (this._apellidoMaterno) {
@@ -395,6 +407,12 @@ export class Colaborator extends BaseEntity {
 
   public terminate(): void {
     this._status = ColaboratorStatus.TERMINATED;
+  }
+
+  public changeGroup(groupId: number): void {
+    if (!groupId) throw new ValidationError('Group ID is required', 'groupId');
+    this._groupId = groupId;
+    this.updatedAt = new Date();
   }
 
   public updateContactInfo(telefono: string, email: string): void {
@@ -542,6 +560,7 @@ export class Colaborator extends BaseEntity {
       telefonoEmergencia: this._telefonoEmergencia,
       profesion: this._profesion,
       cargo: this._cargo,
+      groupId: this._groupId,
       status: this._status,
       isActive: this.isActive(),
       contractIds: this.contractIds,

--- a/src/domains/colaborators/repositories/colaborator.repository.ts
+++ b/src/domains/colaborators/repositories/colaborator.repository.ts
@@ -3,7 +3,7 @@ import { Colaborator } from '../entities/colaborator.entity';
 import { ColaboratorStatus, DocumentType } from '../value-objects/colaborator-enums';
 
 export interface ColaboratorRepository extends Repository<Colaborator> {
-  findAll(filters?: { contractId?: string }): Promise<Colaborator[]>;
+  findAll(groupId?: number, filters?: { contractId?: string }): Promise<Colaborator[]>;
   findByNumeroDocumento(numeroDocumento: string): Promise<Colaborator | null>;
   findByEmail(email: string): Promise<Colaborator | null>;
   findByNombre(nombre: string): Promise<Colaborator[]>;

--- a/src/domains/colaborators/use-cases/create-colaborator.use-case.ts
+++ b/src/domains/colaborators/use-cases/create-colaborator.use-case.ts
@@ -1,7 +1,8 @@
 import { ColaboratorRepository } from '../repositories/colaborator.repository';
 import { Colaborator, ColaboratorProps } from '../entities/colaborator.entity';
 import { DocumentType, Gender, CivilStatus } from '../value-objects/colaborator-enums';
-import { ConflictError } from '@shared/domain/errors';
+import { ConflictError, ValidationError } from '@shared/domain/errors';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export interface CreateColaboratorRequest {
   tipoDocumento: DocumentType;
@@ -25,11 +26,15 @@ export interface CreateColaboratorRequest {
   telefonoEmergencia?: string;
   profesion: string;
   cargo: string;
+  groupId: number;
   contractIds: string[];
 }
 
 export class CreateColaboratorUseCase {
-  constructor(private readonly colaboratorRepository: ColaboratorRepository) {}
+  constructor(
+    private readonly colaboratorRepository: ColaboratorRepository,
+    private readonly groupRepository: GroupRepository,
+  ) {}
 
   public async execute(request: CreateColaboratorRequest): Promise<Colaborator> {
     // Check if document number already exists
@@ -42,6 +47,12 @@ export class CreateColaboratorUseCase {
     const existingByEmail = await this.colaboratorRepository.findByEmail(request.email);
     if (existingByEmail) {
       throw new ConflictError('Colaborator with this email already exists');
+    }
+
+    // Validate group exists
+    const group = await this.groupRepository.findById(request.groupId);
+    if (!group) {
+      throw new ValidationError('Group not found', 'groupId');
     }
 
     const colaboratorProps: ColaboratorProps = {

--- a/src/domains/colaborators/use-cases/get-colaborator.use-case.ts
+++ b/src/domains/colaborators/use-cases/get-colaborator.use-case.ts
@@ -15,8 +15,8 @@ export class GetColaboratorUseCase {
     return colaborator;
   }
 
-  public async getAll(filters?: { contractId?: string }): Promise<Colaborator[]> {
-    return await this.colaboratorRepository.findAll(filters);
+  public async getAll(groupId?: number, filters?: { contractId?: string }): Promise<Colaborator[]> {
+    return await this.colaboratorRepository.findAll(groupId, filters);
   }
 
   public async getByDocumentNumber(numeroDocumento: string): Promise<Colaborator> {

--- a/src/domains/colaborators/use-cases/update-colaborator.use-case.ts
+++ b/src/domains/colaborators/use-cases/update-colaborator.use-case.ts
@@ -1,7 +1,8 @@
 import { ColaboratorRepository } from '../repositories/colaborator.repository';
 import { Colaborator } from '../entities/colaborator.entity';
-import { NotFoundError, ConflictError } from '@shared/domain/errors';
+import { NotFoundError, ConflictError, ValidationError } from '@shared/domain/errors';
 import { DocumentType, Gender, CivilStatus } from '../value-objects/colaborator-enums';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export interface UpdateColaboratorRequest {
   id: string;
@@ -32,10 +33,15 @@ export interface UpdateColaboratorRequest {
   // Profesional
   profesion?: string;
   cargo?: string;
+  // Grupo
+  groupId?: number;
 }
 
 export class UpdateColaboratorUseCase {
-  constructor(private readonly colaboratorRepository: ColaboratorRepository) {}
+  constructor(
+    private readonly colaboratorRepository: ColaboratorRepository,
+    private readonly groupRepository: GroupRepository,
+  ) {}
 
   public async execute(request: UpdateColaboratorRequest): Promise<Colaborator> {
     const colaborator = await this.colaboratorRepository.findById(request.id);
@@ -130,6 +136,15 @@ export class UpdateColaboratorUseCase {
     // Update cargo if provided
     if (request.cargo) {
       colaborator.updateCargo(request.cargo);
+    }
+
+    // Update group if provided
+    if (request.groupId !== undefined && request.groupId !== colaborator.groupId) {
+      const group = await this.groupRepository.findById(request.groupId);
+      if (!group) {
+        throw new ValidationError('Group not found', 'groupId');
+      }
+      colaborator.changeGroup(request.groupId);
     }
 
     return await this.colaboratorRepository.update(colaborator);

--- a/src/domains/contract/entities/contract.entity.ts
+++ b/src/domains/contract/entities/contract.entity.ts
@@ -30,6 +30,7 @@ interface BaseContractProps {
   dotacionVehiculos?: number;
   employeeId?: string;
   managerId?: string;
+  groupId: number;
   createdAt?: DateType;
   updatedAt?: DateType;
   deletedAt?: DateType | null;
@@ -64,6 +65,7 @@ export type UpdateContractProps = {
   dotacionVehiculos?: number;
   employeeId?: string;
   managerId?: string;
+  groupId?: number;
   userId?: string;
   userRoles?: Array<{ id: number; name: string }>;
 };
@@ -108,6 +110,7 @@ export class Contract {
   status: ContractStatus;
   employeeId?: string;
   managerId?: string;
+  groupId: number;
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date | null;
@@ -152,6 +155,9 @@ export class Contract {
     }
     if (!props.nombreMandante?.trim()) {
       throw new ValidationError('Nombre mandante is required', 'nombreMandante');
+    }
+    if (!props.groupId || props.groupId <= 0) {
+      throw new ValidationError('Group ID is required and must be positive', 'groupId');
     }
     if (props.contractType && !isValid(props.contractType, ContractType)) {
       throw new ValidationError('Invalid contract type', 'contractType');
@@ -262,6 +268,13 @@ export class Contract {
     this.nombreProyecto = nombreProyecto?.trim();
   }
 
+  public changeGroup(groupId: number): void {
+    if (!groupId || groupId <= 0) {
+      throw new ValidationError('Group ID must be positive', 'groupId');
+    }
+    this.groupId = groupId;
+  }
+
   public updateJornadaTrabajo(jornadaTrabajo: string): void {
     this.jornadaTrabajo = parseEnum(jornadaTrabajo, JornadaTrabajo) ?? JornadaTrabajo.COMPLETA;
   }
@@ -334,6 +347,7 @@ export class Contract {
       status: this.status,
       dotacionPersonal: this.dotacionPersonal,
       dotacionVehiculos: this.dotacionVehiculos,
+      groupId: this.groupId,
       startDate: DateUtils.toString(this.startDate),
       endDate: DateUtils.toString(this.endDate),
       duration: this.getDuration(),

--- a/src/domains/contract/repositories/contract.repository.ts
+++ b/src/domains/contract/repositories/contract.repository.ts
@@ -17,7 +17,7 @@ export interface ContractRepository {
   findExpiredContracts(): Promise<Contract[]>;
   findContractsEndingBefore(date: Date): Promise<Contract[]>;
   findById(id: string): Promise<Contract | null>;
-  findAll(): Promise<Contract[]>;
+  findAll(groupId?: number): Promise<Contract[]>;
   save(contract: CreateContractProps): Promise<Contract>;
   update(contract: UpdateContractProps): Promise<Contract>;
   delete(id: string): Promise<void>;

--- a/src/domains/contract/use-cases/create-contract.use-case.ts
+++ b/src/domains/contract/use-cases/create-contract.use-case.ts
@@ -1,11 +1,21 @@
 import { ContractRepository } from '@domains/contract/repositories/contract.repository';
 import { Contract, CreateContractProps } from '@domains/contract/entities/contract.entity';
-import { ConflictError } from '@shared/domain/errors';
+import { ConflictError, ValidationError } from '@shared/domain/errors';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export class CreateContractUseCase {
-  constructor(private readonly contractRepository: ContractRepository) { }
+  constructor(
+    private readonly contractRepository: ContractRepository,
+    private readonly groupRepository: GroupRepository,
+  ) {}
 
   public async execute(request: CreateContractProps): Promise<Contract> {
+    // Validate group exists
+    const group = await this.groupRepository.findById(request.groupId);
+    if (!group) {
+      throw new ValidationError('Group not found', 'groupId');
+    }
+
     // Check if contract number already exists
     const contractExists = await this.contractRepository.existsByContractNumber(request.contractNumber);
     if (contractExists) {

--- a/src/domains/contract/use-cases/get-contract.use-case.ts
+++ b/src/domains/contract/use-cases/get-contract.use-case.ts
@@ -18,8 +18,8 @@ export class GetContractByIdUseCase {
 export class GetAllContractsUseCase {
   constructor(private readonly contractRepository: ContractRepository) {}
 
-  public async execute(): Promise<Contract[]> {
-    return await this.contractRepository.findAll();
+  public async execute(groupId?: number): Promise<Contract[]> {
+    return await this.contractRepository.findAll(groupId);
   }
 }
 

--- a/src/domains/contract/use-cases/update-contract.use-case.ts
+++ b/src/domains/contract/use-cases/update-contract.use-case.ts
@@ -1,10 +1,14 @@
 import { ContractRepository } from '../repositories/contract.repository';
 import { Contract, UpdateContractProps } from '../entities/contract.entity';
-import { NotFoundError } from '@shared/domain/errors';
+import { NotFoundError, ValidationError } from '@shared/domain/errors';
 import { only } from '@shared/utils/objects';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export class UpdateContractUseCase {
-  constructor(private readonly contractRepository: ContractRepository) { }
+  constructor(
+    private readonly contractRepository: ContractRepository,
+    private readonly groupRepository: GroupRepository,
+  ) {}
 
   public async execute(request: UpdateContractProps): Promise<Contract> {
     const contract = await this.contractRepository.findById(request.id);
@@ -85,6 +89,15 @@ export class UpdateContractUseCase {
       );
     }
 
+    // Update group if provided
+    if (request.groupId !== undefined && request.groupId !== contract.groupId) {
+      const group = await this.groupRepository.findById(request.groupId);
+      if (!group) {
+        throw new ValidationError('Group not found', 'groupId');
+      }
+      contract.changeGroup(request.groupId);
+    }
+
     if (request.endDate) {
       contract.extendContract(new Date(request.endDate));
     }
@@ -108,6 +121,7 @@ export class UpdateContractUseCase {
       'jornadaTrabajo',
       'dotacionPersonal',
       'dotacionVehiculos',
+      'groupId',
     ]);
 
     return await this.contractRepository.update(updateFields);

--- a/src/domains/document/entities/document.entity.ts
+++ b/src/domains/document/entities/document.entity.ts
@@ -22,6 +22,7 @@ export interface DocumentProps {
   status?: string;
   requiredForContract?: boolean;
   requiredForColaborator?: boolean;
+  groupId: number;
   createdBy?: string;
   comment?: string | null;
   deletedAt?: Date | null;
@@ -48,6 +49,7 @@ export class Document {
   status: DocumentStatus;
   requiredForContract: boolean;
   requiredForColaborator: boolean;
+  groupId: number;
   createdBy: string | null;
   comment: string | null;
   deletedAt: Date | null;
@@ -119,6 +121,10 @@ export class Document {
 
     if (props.comment && props.comment.trim().length > 1000) {
       throw new ValidationError('El comentario no puede exceder 1000 caracteres');
+    }
+
+    if (!props.groupId) {
+      throw new ValidationError('Group ID is required', 'groupId');
     }
   }
 
@@ -225,6 +231,12 @@ export class Document {
     this.updatedAt = new Date();
   }
 
+  public changeGroup(groupId: number): void {
+    if (!groupId) throw new ValidationError('Group ID is required', 'groupId');
+    this.groupId = groupId;
+    this.updatedAt = new Date();
+  }
+
   public softDelete(deletedBy: string): void {
     this.deletedAt = new Date();
     this.deletedBy = deletedBy;
@@ -308,6 +320,7 @@ export class Document {
       status: this.status,
       requiredForContract: this.requiredForContract,
       requiredForColaborator: this.requiredForColaborator,
+      groupId: this.groupId,
       createdBy: this.createdBy,
       comment: this.comment,
       deletedAt: DateTimeUtils.toString(this.deletedAt, true),

--- a/src/domains/document/repositories/document.repository.ts
+++ b/src/domains/document/repositories/document.repository.ts
@@ -3,7 +3,7 @@ import { DocumentStatus } from '../value-objects/document-enums';
 
 export interface DocumentRepository {
   findById(id: string): Promise<Document | null>;
-  findAll(filters?: {
+  findAll(groupId?: number, filters?: {
     contractId?: string;
     requiredForContract?: boolean;
     requiredForColaborator?: boolean;

--- a/src/domains/document/use-cases/assign-documents-to-group.use-case.ts
+++ b/src/domains/document/use-cases/assign-documents-to-group.use-case.ts
@@ -4,6 +4,7 @@ import { Document, DocumentProps } from '../entities/document.entity';
 import { DocumentHistoryProps } from '../entities/document-history.entity';
 import { DocumentAction } from '../value-objects/document-enums';
 import { ContractRepository } from '@domains/contract/repositories/contract.repository';
+import { ColaboratorRepository } from '@domains/colaborators/repositories/colaborator.repository';
 import { ValidationError } from '@shared/domain/errors';
 
 export interface AssignDocumentsToGroupRequest {
@@ -30,6 +31,7 @@ export class AssignDocumentsToGroupUseCase {
     private readonly documentRepository: DocumentRepository,
     private readonly documentHistoryRepository: DocumentHistoryRepository,
     private readonly contractRepository: ContractRepository,
+    private readonly colaboratorRepository: ColaboratorRepository,
   ) {}
 
   public async execute(request: AssignDocumentsToGroupRequest): Promise<AssignDocumentsToGroupResult> {
@@ -46,6 +48,12 @@ export class AssignDocumentsToGroupUseCase {
     const skipped: string[] = [];
 
     for (const colaboratorId of request.colaboratorIds) {
+      const colaborator = await this.colaboratorRepository.findById(colaboratorId);
+      if (!colaborator) {
+        skipped.push(colaboratorId);
+        continue;
+      }
+
       const exists = await this.documentRepository.existsByTypeSubtypeContractColaborator(
         request.documentTypeId,
         request.documentSubtypeId,
@@ -67,8 +75,7 @@ export class AssignDocumentsToGroupUseCase {
         contractId: request.contractId,
         createdBy: request.createdBy,
         requiredForContract: request.requiredForContract,
-        requiredForColaborator: request.requiredForColaborator,
-      };
+        requiredForColaborator: request.requiredForColaborator,        groupId: colaborator.groupId      };
       const doc = Document.create(props);
       const saved = await this.documentRepository.save(doc);
       created.push(saved);

--- a/src/domains/document/use-cases/create-document.use-case.ts
+++ b/src/domains/document/use-cases/create-document.use-case.ts
@@ -4,6 +4,7 @@ import { Document, DocumentProps } from '../entities/document.entity';
 import { DocumentHistoryProps } from '../entities/document-history.entity';
 import { DocumentAction } from '../value-objects/document-enums';
 import { ValidationError } from '@shared/domain/errors';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export interface CreateDocumentRequest {
   documentTypeId: string;
@@ -17,6 +18,7 @@ export interface CreateDocumentRequest {
   documentUrl?: string;
   requiredForContract?: boolean;
   requiredForColaborator?: boolean;
+  groupId: number;
   createdBy?: string;
   comment?: string;
 }
@@ -25,9 +27,16 @@ export class CreateDocumentUseCase {
   constructor(
     private readonly documentRepository: DocumentRepository,
     private readonly documentHistoryRepository: DocumentHistoryRepository,
+    private readonly groupRepository: GroupRepository,
   ) {}
 
   public async execute(request: CreateDocumentRequest): Promise<Document> {
+    // Validate group exists
+    const group = await this.groupRepository.findById(request.groupId);
+    if (!group) {
+      throw new ValidationError('Group not found', 'groupId');
+    }
+
     // Verificando que no haya documentos duplicados
     if (request.colaboratorIds && request.colaboratorIds.length > 0) {
       let exists = false;
@@ -64,6 +73,7 @@ export class CreateDocumentUseCase {
       documentUrl: request.documentUrl,
       requiredForContract: request.requiredForContract,
       requiredForColaborator: request.requiredForColaborator,
+      groupId: request.groupId,
       createdBy: request.createdBy,
     };
 

--- a/src/domains/document/use-cases/get-document.use-case.ts
+++ b/src/domains/document/use-cases/get-document.use-case.ts
@@ -18,13 +18,13 @@ export class GetDocumentByIdUseCase {
 export class GetAllDocumentsUseCase {
   constructor(private readonly documentRepository: DocumentRepository) {}
 
-  public async execute(filters?: {
+  public async execute(groupId?: number, filters?: {
     contractId?: string;
     requiredForContract?: boolean;
     requiredForColaborator?: boolean;
     status?: DocumentStatus | DocumentStatus[];
   }): Promise<Document[]> {
-    return await this.documentRepository.findAll(filters);
+    return await this.documentRepository.findAll(groupId, filters);
   }
 }
 

--- a/src/domains/document/use-cases/update-document.use-case.ts
+++ b/src/domains/document/use-cases/update-document.use-case.ts
@@ -4,6 +4,7 @@ import { Document } from '../entities/document.entity';
 import { DocumentHistoryProps } from '../entities/document-history.entity';
 import { DocumentAction } from '../value-objects/document-enums';
 import { NotFoundError, ValidationError } from '@shared/domain/errors';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
 
 export interface UpdateDocumentRequest {
   documentTypeId?: string;
@@ -17,6 +18,7 @@ export interface UpdateDocumentRequest {
   documentUrl?: string;
   requiredForContract?: boolean;
   requiredForColaborator?: boolean;
+  groupId?: number;
   updatedBy?: string;
   comment?: string;
 }
@@ -25,6 +27,7 @@ export class UpdateDocumentUseCase {
   constructor(
     private readonly documentRepository: DocumentRepository,
     private readonly documentHistoryRepository: DocumentHistoryRepository,
+    private readonly groupRepository: GroupRepository,
   ) {}
 
   public async execute(id: string, request: UpdateDocumentRequest): Promise<Document> {
@@ -75,6 +78,15 @@ export class UpdateDocumentUseCase {
 
     if (request.requiredForColaborator !== undefined) {
       document.updateRequiredForColaborator(request.requiredForColaborator);
+    }
+
+    // Update group if provided
+    if (request.groupId !== undefined && request.groupId !== document.groupId) {
+      const group = await this.groupRepository.findById(request.groupId);
+      if (!group) {
+        throw new ValidationError('Group not found', 'groupId');
+      }
+      document.changeGroup(request.groupId);
     }
 
     // Verificar que no haya documentos duplicados

--- a/src/domains/family/use-cases/assign-documents-from-family.use-case.ts
+++ b/src/domains/family/use-cases/assign-documents-from-family.use-case.ts
@@ -2,6 +2,7 @@ import { DocumentRepository } from '@domains/document/repositories/document.repo
 import { DocumentHistoryRepository } from '@domains/document/repositories/document-history.repository';
 import { IDocumentModelRepository } from '@domains/document-model/repositories/document-model.repository.interface';
 import { ContractRepository } from '@domains/contract/repositories/contract.repository';
+import { ColaboratorRepository } from '@domains/colaborators/repositories/colaborator.repository';
 import { IFamilyRepository } from '../repositories/family.repository.interface';
 import { Document, DocumentProps } from '@domains/document/entities/document.entity';
 import { DocumentHistoryProps } from '@domains/document/entities/document-history.entity';
@@ -28,6 +29,7 @@ export class AssignDocumentsFromFamilyUseCase {
     private readonly documentRepository: DocumentRepository,
     private readonly documentHistoryRepository: DocumentHistoryRepository,
     private readonly contractRepository: ContractRepository,
+    private readonly colaboratorRepository: ColaboratorRepository,
   ) {}
 
   public async execute(request: AssignDocumentsFromFamilyRequest): Promise<AssignDocumentsFromFamilyResult> {
@@ -59,6 +61,12 @@ export class AssignDocumentsFromFamilyUseCase {
 
     // Para cada colaborador, crear un documento por cada modelo
     for (const colaboratorId of request.colaboratorIds) {
+      const colaborator = await this.colaboratorRepository.findById(colaboratorId);
+      if (!colaborator) {
+        skipped.push(colaboratorId);
+        continue;
+      }
+
       for (const model of models) {
         // Verificar si ya existe un documento con esta combinación
         const exists = await this.documentRepository.existsByTypeSubtypeContractColaborator(
@@ -86,6 +94,7 @@ export class AssignDocumentsFromFamilyUseCase {
           createdBy: request.createdBy,
           requiredForContract: model.requiredForContract,
           requiredForColaborator: model.requiredForColaborator,
+          groupId: colaborator.groupId,
         };
 
         const doc = Document.create(props);

--- a/src/presentation/controllers/colaborators.controller.ts
+++ b/src/presentation/controllers/colaborators.controller.ts
@@ -48,6 +48,7 @@ export class ColaboratorController {
 
   public getAllColaborators = asyncHandler(async (req: Request, res: Response) => {
     const { filter } = req.query;
+    const groupId = req.groupId;
     const filters: any = {};
     if (filter && typeof filter === 'object') {
       const contractId = (filter as any).contractId;
@@ -56,7 +57,7 @@ export class ColaboratorController {
       }
     }
 
-    const colaborators = await this.getColaboratorUseCase.getAll(Object.keys(filters).length > 0 ? filters : undefined);
+    const colaborators = await this.getColaboratorUseCase.getAll(groupId, Object.keys(filters).length > 0 ? filters : undefined);
     res.status(200).json({
       success: true,
       data: colaborators.map((colaborator: any) => toColaboratorResponseDto(colaborator)),

--- a/src/presentation/controllers/contract.controller.ts
+++ b/src/presentation/controllers/contract.controller.ts
@@ -102,6 +102,7 @@ export class ContractController {
       nombreProyecto: json.nombreProyecto,
       jornadaTrabajo: json.jornadaTrabajo as JornadaTrabajo,
       status: json.status as ContractStatus,
+      groupId: json.groupId,
       duration: json.duration,
       isActive: json.isActive,
       isExpired: json.isExpired,
@@ -112,7 +113,11 @@ export class ContractController {
   }
 
   public createContract = asyncHandler(async (req: Request, res: Response) => {
-    const contract = await this.createContractUseCase.execute(req.body as CreateContractDto);
+    const dto: CreateContractDto = req.body;
+    const contract = await this.createContractUseCase.execute({
+      ...dto,
+      groupId: dto.groupId,
+    });
     res.status(201).json({
       success: true,
       data: this.toResponseDto(contract),
@@ -130,7 +135,7 @@ export class ContractController {
   });
 
   public getAllContracts = asyncHandler(async (req: Request, res: Response) => {
-    const contracts = await this.getAllContractsUseCase.execute();
+    const contracts = await this.getAllContractsUseCase.execute(req.groupId);
     res.status(200).json({
       success: true,
       data: contracts.map((contract: Contract) => this.toResponseDto(contract)),

--- a/src/presentation/controllers/document.controller.ts
+++ b/src/presentation/controllers/document.controller.ts
@@ -112,6 +112,7 @@ export class DocumentController {
       documentUrl: dto.documentUrl,
       requiredForContract: dto.requiredForContract,
       requiredForColaborator: dto.requiredForColaborator,
+      groupId: dto.groupId,
       createdBy: req.user?.id,
     });
 
@@ -140,7 +141,7 @@ export class DocumentController {
     const requiredForColaborator = filterObj.requiredForColaborator === 'true' ? true : undefined;
     const status = filterObj.status;
 
-    const documents = await this.getAllDocumentsUseCase.execute({
+    const documents = await this.getAllDocumentsUseCase.execute(req.groupId, {
       contractId,
       requiredForContract,
       requiredForColaborator,

--- a/src/presentation/dto/colaborator/create-colaborator.dto.ts
+++ b/src/presentation/dto/colaborator/create-colaborator.dto.ts
@@ -22,5 +22,6 @@ export interface CreateColaboratorDto {
   telefonoEmergencia?: string;
   profesion: string;
   cargo: string;
+  groupId: number;
   contractIds: string[];
 }

--- a/src/presentation/dto/colaborator/update-colaborator.dto.ts
+++ b/src/presentation/dto/colaborator/update-colaborator.dto.ts
@@ -26,4 +26,6 @@ export interface UpdateColaboratorDto {
   // Profesional
   profesion?: string;
   cargo?: string;
+  // Grupo
+  groupId?: number;
 }

--- a/src/presentation/dto/contract/contract-response.dto.ts
+++ b/src/presentation/dto/contract/contract-response.dto.ts
@@ -22,6 +22,7 @@ export interface ContractResponseDto {
   nombreProyecto?: string;
   jornadaTrabajo: JornadaTrabajo;
   status: ContractStatus;
+  groupId: number;
   duration?: number | null; // days
   isActive: boolean;
   isExpired: boolean;
@@ -52,6 +53,7 @@ export function toContractResponseDto(contract: Contract): ContractResponseDto {
     nombreProyecto: json.nombreProyecto,
     jornadaTrabajo: json.jornadaTrabajo as JornadaTrabajo,
     status: json.status as ContractStatus,
+    groupId: json.groupId,
     duration: json.duration,
     isActive: json.isActive,
     isExpired: json.isExpired,

--- a/src/presentation/dto/contract/create-contract.dto.ts
+++ b/src/presentation/dto/contract/create-contract.dto.ts
@@ -18,4 +18,5 @@ export interface CreateContractDto {
   descripcionServicio?: string;
   nombreProyecto?: string;
   jornadaTrabajo: JornadaTrabajo;
+  groupId: number;
 }

--- a/src/presentation/dto/contract/update-contract.dto.ts
+++ b/src/presentation/dto/contract/update-contract.dto.ts
@@ -16,4 +16,5 @@ export interface UpdateContractDto {
   dotacionPersonal?: number;
   dotacionVehiculos?: number;
   jornadaTrabajo?: string;
+  groupId?: number;
 }

--- a/src/presentation/dto/document/create-document.dto.ts
+++ b/src/presentation/dto/document/create-document.dto.ts
@@ -10,4 +10,5 @@ export interface CreateDocumentDto {
   documentUrl?: string;
   requiredForContract?: boolean;
   requiredForColaborator?: boolean;
+  groupId: number;
 }

--- a/src/presentation/dto/document/update-document.dto.ts
+++ b/src/presentation/dto/document/update-document.dto.ts
@@ -11,4 +11,5 @@ export interface UpdateDocumentDto {
   comment?: string;
   requiredForContract?: boolean;
   requiredForColaborator?: boolean;
+  groupId?: number;
 }

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -44,6 +44,7 @@ export const createContractSchema = Joi.object({
   descripcionServicio: Joi.string().max(1000).optional(),
   nombreProyecto: Joi.string().max(100).optional(),
   jornadaTrabajo: Joi.string().valid(...Object.values(JornadaTrabajo)).required(),
+  groupId: Joi.number().integer().positive().required(),
   status: Joi.string().valid(...Object.values(ContractStatus)).optional().default(ContractStatus.DRAFT),
 });
 
@@ -69,6 +70,7 @@ export const updateContractSchema = Joi.object({
   jornadaTrabajo: Joi.string().valid(...Object.values(JornadaTrabajo)).optional(),
   dotacionPersonal: Joi.number().integer().min(0).optional(),
   dotacionVehiculos: Joi.number().integer().min(0).optional(),
+  groupId: Joi.number().integer().positive().optional(),
 }).min(1);
 
 export const getContractByIdSchema = Joi.object({

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -208,6 +208,7 @@ export const createDocumentSchema = Joi.object({
   documentUrl: Joi.string().optional().allow('', null),
   requiredForContract: Joi.boolean().optional().default(false),
   requiredForColaborator: Joi.boolean().optional().default(false),
+  groupId: Joi.number().integer().positive().required(),
 }).unknown(true);
 
 export const updateDocumentSchema = Joi.object({
@@ -233,6 +234,7 @@ export const updateDocumentSchema = Joi.object({
   documentUrl: Joi.string().optional().allow(null, ''),
   requiredForContract: Joi.boolean().optional(),
   requiredForColaborator: Joi.boolean().optional(),
+  groupId: Joi.number().integer().positive().optional(),
 }).min(1).unknown(true); // Permitir campos desconocidos
 
 export const getDocumentByIdSchema = Joi.object({

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -113,6 +113,7 @@ export const createColaboratorSchema = Joi.object({
   telefonoEmergencia: Joi.string().min(7).max(20).optional(),
   profesion: Joi.string().min(2).max(100).required(),
   cargo: Joi.string().min(2).max(100).required(),
+  groupId: Joi.number().integer().positive().required(),
   contractIds: Joi.array().items(Joi.string().uuid()).min(1).required().messages({
     'array.min': 'At least one contract is required',
     'any.required': 'Contracts are required',
@@ -154,6 +155,8 @@ export const updateColaboratorSchema = Joi.object({
   // Profesional
   profesion: Joi.string().min(2).max(100).optional(),
   cargo: Joi.string().min(2).max(100).optional(),
+  // Grupo
+  groupId: Joi.number().integer().positive().optional(),
 }).min(1);
 
 export const createDocumentTypeSchema = Joi.object({

--- a/src/presentation/routes/colaborators.routes.ts
+++ b/src/presentation/routes/colaborators.routes.ts
@@ -6,57 +6,115 @@ import {
   updateColaboratorSchema,
   updateColaboratorContractsSchema,
 } from '../dto/validation-schemas';
+import { auth } from '@shared/middleware/auth.middleware';
+import { authorize } from '@shared/middleware/authorize.middleware';
+import { assignGroup, changeGroup, getByGroup } from '@shared/middleware/group.middleware';
 
 export const createColaboratorRoutes = (colaboratorController: ColaboratorController): Router => {
   const router = Router();
+  router.use(auth);
 
   // POST /api/colaborators - Create a new colaborator
-  router.post('/', validateRequest(createColaboratorSchema), colaboratorController.createColaborator);
+  router.post('/',
+    authorize('colaborator:create'),
+    assignGroup(),
+    validateRequest(createColaboratorSchema),
+    colaboratorController.createColaborator,
+  );
 
   // GET /api/colaborators - Get all colaborators
-  router.get('/', colaboratorController.getAllColaborators);
+  router.get('/',
+    authorize('colaborator:read'),
+    getByGroup(),
+    colaboratorController.getAllColaborators,
+  );
 
   // GET /api/colaborators/active - Get active colaborators
-  router.get('/active', colaboratorController.getActiveColaborators);
+  router.get('/active',
+    authorize('colaborator:read'),
+    colaboratorController.getActiveColaborators,
+  );
 
   // GET /api/colaborators/search - Search colaborators by name (query: ?name=Juan)
-  router.get('/search', colaboratorController.searchColaboratorsByName);
+  router.get('/search',
+    authorize('colaborator:read'),
+    colaboratorController.searchColaboratorsByName,
+  );
 
   // GET /api/colaborators/document/:numeroDocumento - Get colaborator by document number
-  router.get('/document/:numeroDocumento', colaboratorController.getColaboratorByDocumentNumber);
+  router.get('/document/:numeroDocumento',
+    authorize('colaborator:read'),
+    colaboratorController.getColaboratorByDocumentNumber,
+  );
 
   // GET /api/colaborators/email/:email - Get colaborator by email
-  router.get('/email/:email', colaboratorController.getColaboratorByEmail);
+  router.get('/email/:email',
+    authorize('colaborator:read'),
+    colaboratorController.getColaboratorByEmail,
+  );
 
   // GET /api/colaborators/:id - Get colaborator by ID
-  router.get('/:id', colaboratorController.getColaboratorById);
+  router.get('/:id',
+    authorize('colaborator:read'),
+    colaboratorController.getColaboratorById,
+  );
 
   // GET /api/colaborators/:id/groups - Get colaborator groups
-  router.get('/:id/groups', colaboratorController.getColaboratorGroups);
+  router.get('/:id/groups',
+    authorize('colaborator:read'),
+    colaboratorController.getColaboratorGroups,
+  );
 
   // GET /api/colaborators/:id/contracts - Get colaborator contracts
-  router.get('/:id/contracts', colaboratorController.getColaboratorContracts);
+  router.get('/:id/contracts',
+    authorize('colaborator:read'),
+    colaboratorController.getColaboratorContracts,
+  );
 
   // PUT /api/colaborators/:id/contracts - Update colaborator contracts
-  router.put('/:id/contracts', validateRequest(updateColaboratorContractsSchema), colaboratorController.updateColaboratorContracts);
+  router.put('/:id/contracts',
+    authorize('colaborator:update'),
+    validateRequest(updateColaboratorContractsSchema),
+    colaboratorController.updateColaboratorContracts,
+  );
 
   // PUT /api/colaborators/:id - Update colaborator
-  router.put('/:id', validateRequest(updateColaboratorSchema), colaboratorController.updateColaborator);
+  router.put('/:id',
+    authorize('colaborator:update'),
+    changeGroup(),
+    validateRequest(updateColaboratorSchema),
+    colaboratorController.updateColaborator,
+  );
 
   // PATCH /api/colaborators/:id/activate - Activate colaborator
-  router.patch('/:id/activate', colaboratorController.activateColaborator);
+  router.patch('/:id/activate',
+    authorize('colaborator:update'),
+    colaboratorController.activateColaborator,
+  );
 
   // PATCH /api/colaborators/:id/suspend - Suspend colaborator
-  router.patch('/:id/suspend', colaboratorController.suspendColaborator);
+  router.patch('/:id/suspend',
+    authorize('colaborator:update'),
+    colaboratorController.suspendColaborator,
+  );
 
   // PATCH /api/colaborators/:id/deactivate - Deactivate colaborator
-  router.patch('/:id/deactivate', colaboratorController.deactivateColaborator);
+  router.patch('/:id/deactivate',
+    authorize('colaborator:update'),
+    colaboratorController.deactivateColaborator,
+  );
 
   // PATCH /api/colaborators/:id/terminate - Terminate colaborator
-  router.patch('/:id/terminate', colaboratorController.terminateColaborator);
+  router.patch('/:id/terminate',
+    authorize('colaborator:update'),
+    colaboratorController.terminateColaborator,
+  );
 
   // DELETE /api/colaborators/:id - Delete (soft-delete) colaborator
-  router.delete('/:id', colaboratorController.deleteColaborator);
+  router.delete('/:id',
+    authorize('colaborator:delete'),
+    colaboratorController.deleteColaborator,
+  );
 
   return router;
 };

--- a/src/presentation/routes/contract.routes.test.ts
+++ b/src/presentation/routes/contract.routes.test.ts
@@ -25,7 +25,8 @@ describe('ContractController', () => {
     const dependencyContainer = new DependencyContainer();
     await dependencyContainer.initialize();
     colaboratorRepository = dependencyContainer.getColaboratorRepository();
-    createColaboratorUseCase = new CreateColaboratorUseCase(colaboratorRepository);
+    const groupRepository = dependencyContainer.getGroupRepository();
+    createColaboratorUseCase = new CreateColaboratorUseCase(colaboratorRepository, groupRepository);
   });
 
   beforeEach(async () => {
@@ -467,6 +468,7 @@ describe('ContractController', () => {
       const colaborator = await createColaboratorUseCase.execute({
         ...colaboratorDto,
         contractIds: [otherContractId],
+        groupId: 1,
       });
       colaboratorId = colaborator.id;
     });

--- a/src/presentation/routes/contract.routes.ts
+++ b/src/presentation/routes/contract.routes.ts
@@ -9,16 +9,23 @@ import {
 } from '../dto/validation-schemas';
 import { auth } from '@shared/middleware/auth.middleware';
 import { authorize } from '@shared/middleware/authorize.middleware';
+import { assignGroup, changeGroup, getByGroup } from '@shared/middleware/group.middleware';
 
 export const createContractRoutes = (contractController: ContractController): Router => {
   const router = Router();
   router.use(auth);
 
   // POST /api/contracts - Create a new contract
-  router.post('/', authorize('contract:create'), validateRequest(createContractSchema, true), contractController.createContract);
+  router.post(
+    '/',
+    authorize('contract:create'),
+    assignGroup(),
+    validateRequest(createContractSchema, true),
+    contractController.createContract,
+  );
 
   // GET /api/contracts - Get all contracts
-  router.get('/', authorize('contract:read'), contractController.getAllContracts);
+  router.get('/', authorize('contract:read'), getByGroup(), contractController.getAllContracts);
 
   // GET /api/contracts/active - Get active contracts
   router.get('/active', authorize('contract:read'), contractController.getActiveContracts);
@@ -51,7 +58,13 @@ export const createContractRoutes = (contractController: ContractController): Ro
   router.get('/:id', authorize('contract:read'), contractController.getContractById);
 
   // PUT /api/contracts/:id - Update contract
-  router.put('/:id', authorize('contract:update'), validateRequest(updateContractSchema, true), contractController.updateContract);
+  router.put(
+    '/:id',
+    authorize('contract:update'),
+    changeGroup(),
+    validateRequest(updateContractSchema, true),
+    contractController.updateContract,
+  );
 
   // PATCH /api/contracts/:id/activate - Activate contract
   router.patch('/:id/activate', authorize('contract:update'), contractController.activateContract);

--- a/src/presentation/routes/document.routes.ts
+++ b/src/presentation/routes/document.routes.ts
@@ -4,6 +4,7 @@ import { validateRequest } from '@shared/middleware/validation';
 import { createDocumentSchema, updateDocumentSchema } from '../dto/validation-schemas';
 import { auth } from '@shared/middleware/auth.middleware';
 import { authorize } from '@shared/middleware/authorize.middleware';
+import { assignGroup, changeGroup, getByGroup } from '@shared/middleware/group.middleware';
 import { RequestHandler } from 'express';
 
 export const createDocumentRoutes = (
@@ -18,7 +19,12 @@ export const createDocumentRoutes = (
   router.use(auth);
 
   // POST routes
-  router.post('/', authorize('document:create'), validateRequest(createDocumentSchema, true), controller.createDocument);
+  router.post('/',
+    authorize('document:create'),
+    assignGroup(),
+    validateRequest(createDocumentSchema, true),
+    controller.createDocument,
+  );
   router.post('/assign-to-group', authorize('document:create'), controller.assignDocumentsToGroup);
 
   // GET routes - specific routes before parameterized routes
@@ -27,7 +33,11 @@ export const createDocumentRoutes = (
   router.get('/by-contract/:contractId', authorize('document:read'), controller.getDocumentsByContractId);
   router.get('/by-type-subtype/:typeId/:subtypeId', authorize('document:read'), controller.getDocumentsByTypeAndSubtypeId);
   router.get('/by-colaborator/:colaboratorId', authorize('document:read'), controller.getDocumentsByColaboratorId);
-  router.get('/', authorize('document:read'), controller.getAllDocuments);
+  router.get('/',
+    authorize('document:read'),
+    getByGroup(),
+    controller.getAllDocuments,
+  );
   router.get('/:id', authorize('document:read'), controller.getDocumentById);
 
   // PUT routes
@@ -37,7 +47,12 @@ export const createDocumentRoutes = (
   router.put('/:id/approve', authorize('document:review'), contractReviewerMiddleware, controller.approveDocument);
   router.put('/:id/reject', authorize('document:review'), contractReviewerMiddleware, controller.rejectDocument);
   router.put('/:id/reject-with-comments', authorize('document:review'), contractReviewerMiddleware, controller.rejectDocumentWithComments);
-  router.put('/:id', authorize('document:update'), validateRequest(updateDocumentSchema, true), controller.updateDocument);
+  router.put('/:id',
+    authorize('document:update'),
+    changeGroup(),
+    validateRequest(updateDocumentSchema, true),
+    controller.updateDocument,
+  );
 
   // DELETE routes
   router.delete('/:id', authorize('document:delete'), controller.deleteDocument);

--- a/src/shared/infrastructure/database/entities/colaborator-group.entity.ts
+++ b/src/shared/infrastructure/database/entities/colaborator-group.entity.ts
@@ -109,6 +109,7 @@ export class ColaboratorGroupEntity implements ColaboratorGroupProps {
       updatedAt: entity.updatedAt instanceof Date
         ? entity.updatedAt
         : new Date(entity.updatedAt),
+      groupId: entity.groupId,
       contractIds: entity.contracts?.map(c => c.id),
     };
     return Colaborator.fromPersistence(props);

--- a/src/shared/infrastructure/database/entities/colaborators.entity.ts
+++ b/src/shared/infrastructure/database/entities/colaborators.entity.ts
@@ -92,6 +92,10 @@ export class ColaboratorEntity {
   @Column({ type: 'varchar', length: 100 })
   cargo!: string;
 
+  @Column({ type: 'integer', name: 'group_id' })
+  @Index('IDX_colaborators_group_id')
+  groupId!: number;
+
   @EnumColumn({
     enum: ['activo', 'inactivo', 'suspendido', 'terminado'],
     default: 'activo',

--- a/src/shared/infrastructure/database/entities/contract.entity.ts
+++ b/src/shared/infrastructure/database/entities/contract.entity.ts
@@ -21,6 +21,7 @@ import { DivisionEntity } from './division.entity';
 @Index('IDX_contracts_nombre_colaborador', ['nombreColaborador'])
 @Index('IDX_contracts_contract_type', ['contractType'])
 @Index('IDX_contracts_status', ['status'])
+@Index('IDX_contracts_group_id', ['groupId'])
 export class ContractEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
@@ -102,6 +103,9 @@ export class ContractEntity {
     default: 'draft',
   })
   status!: string;
+
+  @Column({ name: 'group_id', type: 'integer' })
+  groupId!: number;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt!: Date;

--- a/src/shared/infrastructure/database/entities/document.entity.ts
+++ b/src/shared/infrastructure/database/entities/document.entity.ts
@@ -20,6 +20,7 @@ import { UserEntity } from './user.entity';
 @Entity('documents')
 @Index('IDX_documents_status', ['status'])
 @Index('IDX_documents_deleted_at', ['deletedAt'])
+@Index('IDX_documents_group_id', ['groupId'])
 export class DocumentEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
@@ -76,6 +77,9 @@ export class DocumentEntity {
 
   @Column({ name: 'required_for_colaborator', type: 'boolean', default: false })
   requiredForColaborator!: boolean;
+
+  @Column({ name: 'group_id', type: 'integer' })
+  groupId!: number;
 
   @Column({ name: 'created_by', type: 'varchar', length: 36, nullable: true })
   createdBy?: string;

--- a/src/shared/infrastructure/database/migrations/1765914699172-RemoveColaboratorIdFromDocumentsTable.ts
+++ b/src/shared/infrastructure/database/migrations/1765914699172-RemoveColaboratorIdFromDocumentsTable.ts
@@ -1,51 +1,66 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey, TableIndex } from 'typeorm';
 
 export class RemoveColaboratorIdFromDocumentsTable1765914699172 implements MigrationInterface {
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Drop the old unique index that included colaboratorId
-    await queryRunner.query(
-      `ALTER TABLE \`documents\` DROP INDEX \`UQ_DOCUMENTS_TEMPLATE_CONTRACT_COLABORATOR\``,
-    );
+    await queryRunner.dropIndex('documents', 'UQ_DOCUMENTS_TEMPLATE_CONTRACT_COLABORATOR');
 
     // Drop the foreign key constraint for colaboratorId
-    await queryRunner.query(
-      `ALTER TABLE \`documents\` DROP FOREIGN KEY \`FK_DOCUMENTS_COLABORATOR\``,
-    );
+    await queryRunner.dropForeignKey('documents', 'FK_DOCUMENTS_COLABORATOR');
 
     // Drop the colaboratorId column
-    await queryRunner.query(
-      `ALTER TABLE \`documents\` DROP COLUMN \`colaborator_id\``,
-    );
+    await queryRunner.dropColumn('documents', 'colaborator_id');
 
     // Add a new unique index without colaboratorId (if needed for template + contract combo)
-    await queryRunner.query(
-      `CREATE UNIQUE INDEX \`UQ_documents_template_contract\` ON \`documents\` (\`template_id\`, \`contract_id\`)`,
+    await queryRunner.createIndex(
+      'documents',
+      new TableIndex({
+        name: 'UQ_documents_template_contract',
+        columnNames: ['template_id', 'contract_id'],
+        isUnique: true,
+      }),
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     // Drop the new unique index (check if exists first)
     const table = await queryRunner.getTable('documents');
-    if (table && table.indices.find(i => i.name === 'UQ_documents_template_contract')) {
-      await queryRunner.query(
-        `ALTER TABLE \`documents\` DROP INDEX \`UQ_documents_template_contract\``,
-      );
+    if (table && table.indices.find((i) => i.name === 'UQ_documents_template_contract')) {
+      await queryRunner.dropIndex('documents', 'UQ_documents_template_contract');
     }
 
     // Add back the colaboratorId column
-    await queryRunner.query(
-      `ALTER TABLE \`documents\` ADD COLUMN \`colaborator_id\` varchar(36) NOT NULL`,
+    await queryRunner.addColumn(
+      'documents',
+      new TableColumn({
+        name: 'colaborator_id',
+        type: 'varchar',
+        length: '36',
+        isNullable: false,
+      }),
     );
 
     // Add back the foreign key constraint
-    await queryRunner.query(
-      `ALTER TABLE \`documents\` ADD CONSTRAINT \`FK_DOCUMENTS_COLABORATOR\` FOREIGN KEY (\`colaborator_id\`) REFERENCES \`colaborators\`(\`id\`) ON DELETE RESTRICT ON UPDATE CASCADE`,
+    await queryRunner.createForeignKey(
+      'documents',
+      new TableForeignKey({
+        name: 'FK_DOCUMENTS_COLABORATOR',
+        columnNames: ['colaborator_id'],
+        referencedTableName: 'colaborators',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+        onUpdate: 'CASCADE',
+      }),
     );
 
     // Restore the old unique index
-    await queryRunner.query(
-      `CREATE UNIQUE INDEX \`UQ_DOCUMENTS_TEMPLATE_CONTRACT_COLABORATOR\` ON \`documents\` (\`template_id\`, \`contract_id\`, \`colaborator_id\`)`,
+    await queryRunner.createIndex(
+      'documents',
+      new TableIndex({
+        name: 'UQ_DOCUMENTS_TEMPLATE_CONTRACT_COLABORATOR',
+        columnNames: ['template_id', 'contract_id', 'colaborator_id'],
+        isUnique: true,
+      }),
     );
   }
 }

--- a/src/shared/infrastructure/database/migrations/1765914818094-RemoveColaboratorIdFromDocumentsHistoryTable.ts
+++ b/src/shared/infrastructure/database/migrations/1765914818094-RemoveColaboratorIdFromDocumentsHistoryTable.ts
@@ -1,29 +1,37 @@
-import { MigrationInterface, QueryRunner } from "typeorm";
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
 
 export class RemoveColaboratorIdFromDocumentsHistoryTable1765914818094 implements MigrationInterface {
-
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Drop the foreign key constraint for colaboratorId
-    await queryRunner.query(
-      `ALTER TABLE \`documents_history\` DROP FOREIGN KEY \`FK_DOCUMENTS_HISTORY_COLABORATOR\``,
-    );
+    await queryRunner.dropForeignKey('documents_history', 'FK_DOCUMENTS_HISTORY_COLABORATOR');
 
     // Drop the colaboratorId column
-    await queryRunner.query(
-      `ALTER TABLE \`documents_history\` DROP COLUMN \`colaborator_id\``,
-    );
+    await queryRunner.dropColumn('documents_history', 'colaborator_id');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     // Add back the colaboratorId column
-    await queryRunner.query(
-      `ALTER TABLE \`documents_history\` ADD COLUMN \`colaborator_id\` varchar(36) NOT NULL`,
+    await queryRunner.addColumn(
+      'documents_history',
+      new TableColumn({
+        name: 'colaborator_id',
+        type: 'varchar',
+        length: '36',
+        isNullable: false,
+      }),
     );
 
     // Add back the foreign key constraint
-    await queryRunner.query(
-      `ALTER TABLE \`documents_history\` ADD CONSTRAINT \`FK_DOCUMENTS_HISTORY_COLABORATOR\` FOREIGN KEY (\`colaborator_id\`) REFERENCES \`colaborators\`(\`id\`) ON DELETE RESTRICT ON UPDATE CASCADE`,
+    await queryRunner.createForeignKey(
+      'documents_history',
+      new TableForeignKey({
+        name: 'FK_DOCUMENTS_HISTORY_COLABORATOR',
+        columnNames: ['colaborator_id'],
+        referencedTableName: 'colaborators',
+        referencedColumnNames: ['id'],
+        onDelete: 'RESTRICT',
+        onUpdate: 'CASCADE',
+      }),
     );
   }
-
 }

--- a/src/shared/infrastructure/database/migrations/1769034343023-AddGroupIdToEntities.ts
+++ b/src/shared/infrastructure/database/migrations/1769034343023-AddGroupIdToEntities.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from 'typeorm';
+
+export class AddGroupIdToEntities1769034343023 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add group_id column to colaborators table
+    await queryRunner.addColumn(
+      'colaborators',
+      new TableColumn({
+        name: 'group_id',
+        type: 'integer',
+        isNullable: false,
+        default: 1,
+      }),
+    );
+
+    // Create index on colaborators.group_id
+    await queryRunner.createIndex(
+      'colaborators',
+      new TableIndex({
+        name: 'IDX_colaborators_group_id',
+        columnNames: ['group_id'],
+      }),
+    );
+
+    // Add group_id column to documents table
+    await queryRunner.addColumn(
+      'documents',
+      new TableColumn({
+        name: 'group_id',
+        type: 'integer',
+        isNullable: false,
+        default: 1,
+      }),
+    );
+
+    // Create index on documents.group_id
+    await queryRunner.createIndex(
+      'documents',
+      new TableIndex({
+        name: 'IDX_documents_group_id',
+        columnNames: ['group_id'],
+      }),
+    );
+
+    // Add group_id column to contracts table
+    await queryRunner.addColumn(
+      'contracts',
+      new TableColumn({
+        name: 'group_id',
+        type: 'integer',
+        isNullable: false,
+        default: 1,
+      }),
+    );
+
+    // Create index on contracts.group_id
+    await queryRunner.createIndex(
+      'contracts',
+      new TableIndex({
+        name: 'IDX_contracts_group_id',
+        columnNames: ['group_id'],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop index and column from contracts table
+    await queryRunner.dropIndex('contracts', 'IDX_contracts_group_id');
+    await queryRunner.dropColumn('contracts', 'group_id');
+
+    // Drop index and column from documents table
+    await queryRunner.dropIndex('documents', 'IDX_documents_group_id');
+    await queryRunner.dropColumn('documents', 'group_id');
+
+    // Drop index and column from colaborators table
+    await queryRunner.dropIndex('colaborators', 'IDX_colaborators_group_id');
+    await queryRunner.dropColumn('colaborators', 'group_id');
+  }
+}

--- a/src/shared/infrastructure/database/seed/initial-seeds.ts
+++ b/src/shared/infrastructure/database/seed/initial-seeds.ts
@@ -22,7 +22,6 @@ const adminSections = [
   'permission',
   'role',
   'user',
-  'company',
   'area',
   'division',
 ];

--- a/src/shared/infrastructure/database/seed/sample-seeds.ts
+++ b/src/shared/infrastructure/database/seed/sample-seeds.ts
@@ -127,6 +127,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56922222222',
       profesion: 'Ingeniero',
       cargo: 'Analista',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -148,6 +149,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56944444444',
       profesion: 'Abogada',
       cargo: 'Consultora',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -169,6 +171,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56966666666',
       profesion: 'Técnico',
       cargo: 'Operario',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -190,6 +193,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56988888888',
       profesion: 'Diseñadora',
       cargo: 'UX',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -211,6 +215,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56900000000',
       profesion: 'Desarrollador',
       cargo: 'Backend',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -232,6 +237,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56913131313',
       profesion: 'Analista',
       cargo: 'QA',
+      groupId: 1,
     },
     {
       tipoDocumento: ColabDocType.RUT,
@@ -253,6 +259,7 @@ export async function runSampleSeeds(): Promise<void> {
       telefonoEmergencia: '+56934343434',
       profesion: 'Project Manager',
       cargo: 'PM',
+      groupId: 1,
     },
   ] satisfies ColaboratorProps[];
 
@@ -469,7 +476,7 @@ export async function runSampleSeeds(): Promise<void> {
     const { testFile, ...documentProps } = docData as any;
 
     // Check if document already exists by name
-    const existing = await documentRepo.findAll({ contractId: documentProps.contractId });
+    const existing = await documentRepo.findAll(undefined, { contractId: documentProps.contractId });
     if (existing.some(d => d.name === documentProps.name)) {
       // console.log(`  ⏭️  Documento "${documentProps.name}" ya existe, omitiendo...`);
       continue;

--- a/src/shared/infrastructure/database/seed/sample-seeds.ts
+++ b/src/shared/infrastructure/database/seed/sample-seeds.ts
@@ -2,6 +2,7 @@ import { TypeOrmDocumentTypeRepository } from '@shared/infrastructure/repositori
 import { TypeOrmDocumentSubtypeRepository } from '@shared/infrastructure/repositories/typeorm-document-subtype.repository';
 import { TypeOrmColaboratorRepository } from '@shared/infrastructure/repositories/typeorm-colaborator.repository';
 import { TypeOrmColaboratorGroupRepository } from '@shared/infrastructure/repositories/typeorm-colaborator-group.repository';
+import { TypeOrmGroupRepository } from '@shared/infrastructure/repositories/typeorm-group.repository';
 import { TypeOrmContractRepository } from '@shared/infrastructure/repositories/typeorm-contract.repository';
 import { TypeOrmDocumentRepository } from '@shared/infrastructure/repositories/typeorm-document.repository';
 import { TypeOrmFileRepository } from '@shared/infrastructure/repositories/typeorm-file.repository';
@@ -24,7 +25,8 @@ export async function runSampleSeeds(): Promise<void> {
   const typeRepo = new TypeOrmDocumentTypeRepository();
   const subtypeRepo = new TypeOrmDocumentSubtypeRepository();
   const colaboratorRepo = new TypeOrmColaboratorRepository();
-  const groupRepo = new TypeOrmColaboratorGroupRepository();
+  const colaboratorGroupRepo = new TypeOrmColaboratorGroupRepository();
+  const groupRepo = new TypeOrmGroupRepository();
   const contractRepo = new TypeOrmContractRepository();
 
   const typeNames = ['Personal', 'Legal', 'Operacional'];
@@ -53,6 +55,15 @@ export async function runSampleSeeds(): Promise<void> {
     subtypes.push(saved.id);
   }
 
+  /* Create Group */
+  let testGroup = await groupRepo.findById(1);
+  if (!testGroup) {
+    testGroup = await groupRepo.save({
+      name: 'Grupo de Pruebas',
+      description: 'Grupo de pruebas',
+    });
+  }
+
   /* Create Contracts */
   const today = new Date();
   const contractsData = [
@@ -68,6 +79,7 @@ export async function runSampleSeeds(): Promise<void> {
       endDate: new Date(today.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
       contractType: ContractType.CONSULTORIA,
       jornadaTrabajo: JornadaTrabajo.COMPLETA,
+      groupId: 1,
     },
     {
       rutSociedad: '98.765.432-1',
@@ -81,6 +93,7 @@ export async function runSampleSeeds(): Promise<void> {
       endDate: new Date(today.getTime() + 45 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
       contractType: ContractType.HONORARIOS,
       jornadaTrabajo: JornadaTrabajo.PARCIAL,
+      groupId: 1,
     },
     {
       rutSociedad: '77.777.777-7',
@@ -94,6 +107,7 @@ export async function runSampleSeeds(): Promise<void> {
       endDate: new Date(today.getTime() + 60 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
       contractType: ContractType.OBRA_FAENA,
       jornadaTrabajo: JornadaTrabajo.TURNO,
+      groupId: 1,
     },
   ];
 
@@ -278,16 +292,16 @@ export async function runSampleSeeds(): Promise<void> {
     colaboratorIds.push(saved.id);
   }
 
-  /* Create Groups */
+  /* Create Colaborator Groups */
   const groupNames = ['Equipo A', 'Equipo B', 'Equipo C'];
   const groups: { id: number; name: string; description?: string }[] = [];
   let groupIndex = 0;
   for (const name of groupNames) {
-    let found = await groupRepo.findByName(name);
+    let found = await colaboratorGroupRepo.findByName(name);
     if (!found) {
       // Assign specific contract based on index rotation
       const assignedContractId = contractIds[groupIndex % contractIds.length];
-      const created = await groupRepo.save({
+      const created = await colaboratorGroupRepo.save({
         name,
         description: 'Grupo de prueba',
         colaborators: [] as any,
@@ -306,9 +320,9 @@ export async function runSampleSeeds(): Promise<void> {
     const groupBColabs = [cids[1], cids[3], cids[4], cids[6]];
     const groupCColabs = [cids[2], cids[3], cids[5], cids[6]];
 
-    await groupRepo.update({ id: A.id, colaborators: groupAColabs.map(id => ({ id } as any)) });
-    await groupRepo.update({ id: B.id, colaborators: groupBColabs.map(id => ({ id } as any)) });
-    await groupRepo.update({ id: C.id, colaborators: groupCColabs.map(id => ({ id } as any)) });
+    await colaboratorGroupRepo.update({ id: A.id, colaborators: groupAColabs.map(id => ({ id } as any)) });
+    await colaboratorGroupRepo.update({ id: B.id, colaborators: groupBColabs.map(id => ({ id } as any)) });
+    await colaboratorGroupRepo.update({ id: C.id, colaborators: groupCColabs.map(id => ({ id } as any)) });
   }
 
   /* Create Documents with different statuses */
@@ -362,6 +376,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: true,
       requiredForColaborator: false,
       createdBy: createdById,
+      groupId: 1,
     },
     {
       name: 'Documento en Revisión',
@@ -376,6 +391,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: false,
       requiredForColaborator: true,
       createdBy: createdById,
+      groupId: 1,
       testFile: 'test-document-1.pdf',
     },
     {
@@ -391,6 +407,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: true,
       requiredForColaborator: true,
       createdBy: createdById,
+      groupId: 1,
       testFile: 'test-document-2.pdf',
     },
     {
@@ -406,6 +423,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: false,
       requiredForColaborator: false,
       createdBy: createdById,
+      groupId: 1,
       comment: 'Rechazado por incumplir requisitos',
       testFile: 'test-document-3.pdf',
     },
@@ -422,6 +440,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: true,
       requiredForColaborator: false,
       createdBy: createdById,
+      groupId: 1,
       comment: 'Favor revisar las firmas y volver a enviar',
       testFile: 'test-image-1.jpg',
     },
@@ -438,6 +457,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: false,
       requiredForColaborator: true,
       createdBy: createdById,
+      groupId: 1,
       testFile: 'test-image-2.png',
     },
     {
@@ -453,6 +473,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: false,
       requiredForColaborator: false,
       createdBy: createdById,
+      groupId: 1,
       testFile: 'test-document-1.pdf',
     },
     {
@@ -468,6 +489,7 @@ export async function runSampleSeeds(): Promise<void> {
       requiredForContract: true,
       requiredForColaborator: true,
       createdBy: createdById,
+      groupId: 1,
       testFile: 'test-document-2.pdf',
     },
   ];

--- a/src/shared/infrastructure/repositories/typeorm-colaborator.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-colaborator.repository.ts
@@ -27,12 +27,16 @@ export class TypeOrmColaboratorRepository implements ColaboratorRepository {
     return this.toDomain(colaboratorEntity);
   }
 
-  async findAll(filters?: { contractId?: string }): Promise<Colaborator[]> {
+  async findAll(groupId?: number, filters?: { contractId?: string }): Promise<Colaborator[]> {
     const query = this.repository
       .createQueryBuilder('colaborator')
       .leftJoinAndSelect('colaborator.contracts', 'contracts')
       .where('colaborator.deleted_at IS NULL')
       .orderBy('colaborator.createdAt', 'DESC');
+
+    if (groupId) {
+      query.andWhere('colaborator.group_id = :groupId', { groupId });
+    }
 
     if (filters?.contractId && filters.contractId !== 'undefined' && filters.contractId !== 'null' && filters.contractId.trim() !== '') {
       query.andWhere('contracts.id = :contractId', { contractId: filters.contractId });
@@ -243,6 +247,7 @@ export class TypeOrmColaboratorRepository implements ColaboratorRepository {
       telefonoEmergencia: entity.telefonoEmergencia,
       profesion: entity.profesion,
       cargo: entity.cargo,
+      groupId: entity.groupId,
       status: entity.status as ColaboratorStatus,
       createdAt:
         entity.createdAt instanceof Date
@@ -286,6 +291,7 @@ export class TypeOrmColaboratorRepository implements ColaboratorRepository {
       telefonoEmergencia: colaborator.telefonoEmergencia,
       profesion: colaborator.profesion,
       cargo: colaborator.cargo,
+      groupId: colaborator.groupId,
       status: colaborator.status,
       createdAt: colaborator.createdAt,
       updatedAt: colaborator.updatedAt,

--- a/src/shared/infrastructure/repositories/typeorm-contract.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-contract.repository.ts
@@ -24,9 +24,15 @@ export class TypeOrmContractRepository implements ContractRepository {
     return this.toDomain(contractEntity);
   }
 
-  async findAll(): Promise<Contract[]> {
+  async findAll(groupId?: number): Promise<Contract[]> {
+    const where: any = { deletedAt: IsNull() };
+
+    if (groupId !== undefined) {
+      where.groupId = groupId;
+    }
+
     const contractEntities = await this.repository.find({
-      where: { deletedAt: IsNull() },
+      where,
       relations: ['areaRelation', 'divisionRelation'],
       order: { createdAt: 'DESC' },
     });
@@ -389,6 +395,7 @@ export class TypeOrmContractRepository implements ContractRepository {
       status: entity.status as ContractStatus,
       employeeId: entity.employeeId,
       managerId: entity.managerId,
+      groupId: entity.groupId,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
       deletedAt: entity.deletedAt,
@@ -421,6 +428,7 @@ export class TypeOrmContractRepository implements ContractRepository {
       status: contract.status,
       employeeId: contract.employeeId,
       managerId: contract.managerId,
+      groupId: contract.groupId,
       createdAt: contract.createdAt,
       updatedAt: contract.updatedAt,
       deletedAt: contract.deletedAt || undefined,

--- a/src/shared/infrastructure/repositories/typeorm-document.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document.repository.ts
@@ -23,13 +23,17 @@ export class TypeOrmDocumentRepository implements DocumentRepository {
     return this.toDomain(documentEntity);
   }
 
-  async findAll(filters?: {
+  async findAll(groupId?: number, filters?: {
     contractId?: string;
     requiredForContract?: boolean;
     requiredForColaborator?: boolean;
     status?: DocumentStatus | DocumentStatus[];
   }): Promise<Document[]> {
     const where: any = { deletedAt: IsNull() };
+
+    if (groupId !== undefined) {
+      where.groupId = groupId;
+    }
 
     if (filters?.contractId) {
       where.contractId = filters.contractId;
@@ -239,6 +243,7 @@ export class TypeOrmDocumentRepository implements DocumentRepository {
       requiredForContract: entity.requiredForContract,
       requiredForColaborator: entity.requiredForColaborator,
       comment: entity.comment,
+      groupId: entity.groupId,
       createdBy: entity.createdBy,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
@@ -261,6 +266,7 @@ export class TypeOrmDocumentRepository implements DocumentRepository {
       requiredForContract: document.requiredForContract,
       requiredForColaborator: document.requiredForColaborator,
       comment: document.comment || undefined,
+      groupId: document.groupId,
       createdBy: document.createdBy || undefined,
       createdAt: document.createdAt,
       updatedAt: document.updatedAt,


### PR DESCRIPTION
Se hacen las relaciones de la entidad group con contract, document y colaborator, se utiliza el middleware de group para filtrar las rutas.
Se corrige el sample seeder para crear un group y las relaciones correspondientes.
Se corrige un error del initial seeder por un campo duplicado.
