### PR TITLE
hotfix de editar roles

### DIFF
--- a/src/shared/infrastructure/repositories/typeorm-role.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-role.repository.ts
@@ -66,10 +66,8 @@ export class TypeOrmRoleRepository implements RoleRepository {
       entity.description = props.description;
     }
 
-    if (props.permissions) {
+    if (props.permissions !== undefined) {
       entity.permissions = await this.permissionRepository.findBy({ id: In(props.permissions.map(p => p.id!)) });
-    } else {
-      entity.permissions = [];
     }
 
     const savedEntity = await this.repository.save(entity);


### PR DESCRIPTION
Se corrige el error que al editar un rol se eliminaban todos los permisos
Se actualiza la lógica de los permisos para manejar valores undefined