### PR TITLE
Agrega groupId a repositorios, actualiza use-cases, controllers y routes

### DIFF
--- a/src/domains/area/repositories/area.repository.ts
+++ b/src/domains/area/repositories/area.repository.ts
@@ -2,7 +2,7 @@ import { Area } from "../entities/area.entity";
 
 export interface AreaRepository {
   findById(id: string): Promise<Area | null>;
-  findAll(): Promise<Area[]>;
+  findAll(groupId?: number): Promise<Area[]>;
   create(area: Area): Promise<Area>;
   update(area: Area): Promise<Area>;
   delete(id: string): Promise<void>;

--- a/src/domains/area/use-cases/list-areas.use-case.ts
+++ b/src/domains/area/use-cases/list-areas.use-case.ts
@@ -4,7 +4,7 @@ import { AreaRepository } from "../repositories/area.repository";
 export class ListAreasUseCase {
   constructor(private readonly areaRepository: AreaRepository) {}
 
-  public async execute(): Promise<Area[]> {
-    return await this.areaRepository.findAll();
+  public async execute(groupId?: number): Promise<Area[]> {
+    return await this.areaRepository.findAll(groupId);
   }
 }

--- a/src/domains/colaborator-group/repositories/colaborator-group.repository.ts
+++ b/src/domains/colaborator-group/repositories/colaborator-group.repository.ts
@@ -5,7 +5,7 @@ export interface ColaboratorGroupRepository {
   findById(id: number): Promise<ColaboratorGroup | null>;
   findByName(name: string): Promise<ColaboratorGroup | null>;
   findIn(ids: number[]): Promise<ColaboratorGroup[]>;
-  findAll(): Promise<ColaboratorGroup[]>;
+  findAll(groupId?: number): Promise<ColaboratorGroup[]>;
   save(request: CreateColaboratorGroupProps): Promise<ColaboratorGroup>;
   update(request: UpdateColaboratorGroupProps): Promise<ColaboratorGroup>;
   delete(id: number): Promise<void>;

--- a/src/domains/colaborator-group/use-cases/get-colaborator-group.use-case.ts
+++ b/src/domains/colaborator-group/use-cases/get-colaborator-group.use-case.ts
@@ -17,7 +17,7 @@ export class GetColaboratorGroupByIdUseCase {
 export class GetAllColaboratorGroupsUseCase {
   constructor(private readonly colaboratorGroupRepository: ColaboratorGroupRepository) {}
 
-  async execute(): Promise<ColaboratorGroup[]> {
-    return this.colaboratorGroupRepository.findAll();
+  async execute(groupId?: number): Promise<ColaboratorGroup[]> {
+    return this.colaboratorGroupRepository.findAll(groupId);
   }
 }

--- a/src/domains/division/repositories/division.repository.ts
+++ b/src/domains/division/repositories/division.repository.ts
@@ -2,7 +2,7 @@ import { Division } from "../entities/division.entity";
 
 export interface DivisionRepository {
   findById(id: string): Promise<Division | null>;
-  findAll(): Promise<Division[]>;
+  findAll(groupId?: number): Promise<Division[]>;
   create(division: Division): Promise<Division>;
   update(division: Division): Promise<Division>;
   delete(id: string): Promise<void>;

--- a/src/domains/division/use-cases/list-divisions.use-case.ts
+++ b/src/domains/division/use-cases/list-divisions.use-case.ts
@@ -4,7 +4,7 @@ import { DivisionRepository } from "../repositories/division.repository";
 export class ListDivisionsUseCase {
   constructor(private readonly divisionRepository: DivisionRepository) {}
 
-  public async execute(): Promise<Division[]> {
-    return await this.divisionRepository.findAll();
+  public async execute(groupId?: number): Promise<Division[]> {
+    return await this.divisionRepository.findAll(groupId);
   }
 }

--- a/src/presentation/controllers/area.controller.ts
+++ b/src/presentation/controllers/area.controller.ts
@@ -34,7 +34,8 @@ export class AreaController {
   });
 
   public listAreas = asyncHandler(async (req: Request, res: Response) => {
-    const areas = await this.listAreasUseCase.execute();
+    const groupId = req.auth?.groupId;
+    const areas = await this.listAreasUseCase.execute(groupId);
     res.status(200).json({
       success: true,
       data: areas.map((area) => area.toJSON()),

--- a/src/presentation/controllers/colaborator-group.controller.ts
+++ b/src/presentation/controllers/colaborator-group.controller.ts
@@ -36,7 +36,7 @@ export class ColaboratorGroupController {
   });
 
   public getGroups = asyncHandler(async (req: Request, res: Response) => {
-    const groups = await this.getAllColaboratorGroupsUseCase.execute();
+    const groups = await this.getAllColaboratorGroupsUseCase.execute(req.auth?.groupId);
     res.status(200).json({
       success: true,
       data: groups.map(g => g.toJSON()),

--- a/src/presentation/controllers/division.controller.ts
+++ b/src/presentation/controllers/division.controller.ts
@@ -34,7 +34,8 @@ export class DivisionController {
   });
 
   public listDivisions = asyncHandler(async (req: Request, res: Response) => {
-    const divisions = await this.listDivisionsUseCase.execute();
+    const groupId = req.auth?.groupId;
+    const divisions = await this.listDivisionsUseCase.execute(groupId);
     res.status(200).json({
       success: true,
       data: divisions.map((division) => division.toJSON()),

--- a/src/presentation/dto/colaborator/colaborator-response.dto.ts
+++ b/src/presentation/dto/colaborator/colaborator-response.dto.ts
@@ -28,6 +28,7 @@ export interface ColaboratorResponseDto {
   status: ColaboratorStatus;
   isActive: boolean;
   contractIds?: string[];
+  groupId?: number;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -61,6 +62,7 @@ export const toColaboratorResponseDto = (colaborator: any): ColaboratorResponseD
     status: colaborator.status,
     isActive: colaborator.isActive(),
     contractIds: colaborator.contractIds,
+    groupId: colaborator.groupId,
     createdAt: colaborator.createdAt,
     updatedAt: colaborator.updatedAt,
   };

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -23,9 +23,7 @@ export const getUserByIdSchema = Joi.object({
 export const createContractSchema = Joi.object({
   rutSociedad: Joi.string().trim().min(8).max(12).required(),
   nombreColaborador: Joi.string().trim().min(2).max(100).optional(),
-  startDate: Joi.date().iso().required().min(Joi.ref('$today')).messages({
-    'date.min': 'startDate should be today or later.',
-  }),
+  startDate: Joi.date().iso().required(),
   endDate: Joi.date().iso().optional().greater(Joi.ref('startDate')).messages({
     'date.greater': 'endDate should be after startDate.',
   }),

--- a/src/presentation/routes/area.routes.ts
+++ b/src/presentation/routes/area.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { AreaController } from '../controllers/area.controller';
 import { auth } from '@shared/middleware/auth.middleware';
 import { authorize } from '@shared/middleware/authorize.middleware';
+import { getByGroup } from '@shared/middleware/group.middleware';
 
 export const createAreaRoutes = (areaController: AreaController): Router => {
   const router = Router();
@@ -12,7 +13,7 @@ export const createAreaRoutes = (areaController: AreaController): Router => {
 
   // CRUD Areas (requieren permisos específicos)
   router.post('/', authorize('area:create'), areaController.createArea);
-  router.get('/', authorize('area:read'), areaController.listAreas);
+  router.get('/', authorize('area:read'), getByGroup(), areaController.listAreas);
   router.get('/:id', authorize('area:read'), areaController.getAreaById);
   router.put('/:id', authorize('area:update'), areaController.updateArea);
   router.delete('/:id', authorize('area:delete'), areaController.deleteArea);

--- a/src/presentation/routes/colaborator-group.routes.ts
+++ b/src/presentation/routes/colaborator-group.routes.ts
@@ -4,6 +4,7 @@ import { validateRequest } from '@shared/middleware/validation';
 import { createColaboratorGroupSchema, updateColaboratorGroupSchema, assignColaboratorsToGroupSchema } from '../dto/validation-schemas';
 import { auth } from '@shared/middleware/auth.middleware';
 import { authorize } from '@shared/middleware/authorize.middleware';
+import { getByGroup } from '@shared/middleware/group.middleware';
 
 export const createColaboratorGroupRoutes = (colaboratorGroupController: ColaboratorGroupController): Router => {
   const router = Router();
@@ -11,7 +12,7 @@ export const createColaboratorGroupRoutes = (colaboratorGroupController: Colabor
 
   // CRUD Colaborator Groups
   router.post('/', authorize('colaborator-group:create'), validateRequest(createColaboratorGroupSchema), colaboratorGroupController.createGroup);
-  router.get('/', authorize('colaborator-group:read'), colaboratorGroupController.getGroups);
+  router.get('/', authorize('colaborator-group:read'), getByGroup(), colaboratorGroupController.getGroups);
   router.get('/:id', authorize('colaborator-group:read'), colaboratorGroupController.getGroupById);
   router.put('/:id', authorize('colaborator-group:update'), validateRequest(updateColaboratorGroupSchema), colaboratorGroupController.updateGroup);
   router.delete('/:id', authorize('colaborator-group:delete'), colaboratorGroupController.deleteGroup);

--- a/src/presentation/routes/division.routes.ts
+++ b/src/presentation/routes/division.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { DivisionController } from '../controllers/division.controller';
 import { auth } from '@shared/middleware/auth.middleware';
 import { authorize } from '@shared/middleware/authorize.middleware';
+import { getByGroup } from '@shared/middleware/group.middleware';
 
 export const createDivisionRoutes = (divisionController: DivisionController): Router => {
   const router = Router();
@@ -12,7 +13,7 @@ export const createDivisionRoutes = (divisionController: DivisionController): Ro
 
   // CRUD Divisions (requieren permisos específicos)
   router.post('/', authorize('division:create'), divisionController.createDivision);
-  router.get('/', authorize('division:read'), divisionController.listDivisions);
+  router.get('/', authorize('division:read'), getByGroup(), divisionController.listDivisions);
   router.get('/:id', authorize('division:read'), divisionController.getDivisionById);
   router.put('/:id', authorize('division:update'), divisionController.updateDivision);
   router.delete('/:id', authorize('division:delete'), divisionController.deleteDivision);

--- a/src/shared/infrastructure/repositories/typeorm-area.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-area.repository.ts
@@ -13,8 +13,9 @@ export class TypeOrmAreaRepository implements AreaRepository {
     this.repository = ds.getRepository(AreaEntity);
   }
 
-  async findAll(): Promise<Area[]> {
+  async findAll(groupId?: number): Promise<Area[]> {
     const entities = await this.repository.find({
+      where: groupId ? { groupId } : undefined,
       relations: ['group'],
       order: { createdAt: 'DESC' },
     });

--- a/src/shared/infrastructure/repositories/typeorm-colaborator-group.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-colaborator-group.repository.ts
@@ -25,8 +25,16 @@ export class TypeOrmColaboratorGroupRepository implements ColaboratorGroupReposi
     await this.repository.save(entity);
   }
 
-  async findAll(): Promise<ColaboratorGroup[]> {
-    const entities = await this.repository.find({ relations: ['colaborators'] });
+  async findAll(groupId?: number): Promise<ColaboratorGroup[]> {
+    const qb = this.repository.createQueryBuilder('cg')
+      .leftJoinAndSelect('cg.colaborators', 'colaborators');
+
+    if (groupId !== undefined) {
+      qb.innerJoin('cg.contract', 'contract')
+        .where('contract.groupId = :groupId', { groupId });
+    }
+
+    const entities = await qb.getMany();
     return entities.map(ColaboratorGroupEntity.toDomain);
   }
 

--- a/src/shared/infrastructure/repositories/typeorm-division.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-division.repository.ts
@@ -13,8 +13,9 @@ export class TypeOrmDivisionRepository implements DivisionRepository {
     this.repository = ds.getRepository(DivisionEntity);
   }
 
-  async findAll(): Promise<Division[]> {
+  async findAll(groupId?: number): Promise<Division[]> {
     const entities = await this.repository.find({
+      where: groupId ? { groupId } : undefined,
       relations: ['group', 'area'],
       order: { createdAt: 'DESC' },
     });


### PR DESCRIPTION
- Permitir guardar contrato con cualquier fecha de inicio
- Agrega groupId a los métodos findAll en los repositorios y actualiza los casos de uso y controllers
- Entregar el groupId en el responde-dto de colaborador para poder editarlo en el frontend
- Agrega groupId a los métodos findAll y actualiza los use-cases y routes