### PR TITLE
Agregar funcionalidad de plantillas de documentos y valores de campos

### DIFF
--- a/CALUDE.md
+++ b/CALUDE.md
@@ -1,0 +1,198 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+**Gestion Documental Backend**: REST API for personnel document management system built with **Domain-Driven Design (DDD)** and **Clean Architecture**. Uses Bun runtime, TypeScript, Express.js, MySQL 8.0+, and TypeORM 0.3+.
+
+## Project Structure
+
+```
+src/
+├── domains/              # Business logic (User, Contract, Document, etc.)
+│   ├── {domain}/
+│   │   ├── entities/     # Domain entities (business objects)
+│   │   ├── repositories/ # Repository interfaces
+│   │   ├── use-cases/    # Business use cases (command handlers)
+│   │   └── value-objects/ # Value types (enums, email, salary, etc.)
+├── shared/              # Shared infrastructure
+│   ├── infrastructure/   # Database, external APIs, cache
+│   │   ├── database/     # TypeORM config, migrations, entities
+│   │   ├── repositories/ # Repository implementations
+│   │   └── external-apis/ # HTTP clients
+│   ├── middleware/       # Express middleware (auth, error handling)
+│   ├── domain/           # Shared domain errors
+│   └── utils/            # Utilities (date, file, compare, etc.)
+├── presentation/        # HTTP layer (Controllers, Routes, DTOs)
+│   ├── controllers/      # HTTP handlers
+│   ├── routes/           # Express route definitions
+│   └── dto/              # Request/Response DTOs
+├── index.ts            # Entry point (bootstrap server)
+└── app.ts              # Express app setup, middleware, routes
+```
+
+## Essential Commands
+
+| Command | Purpose |
+|---------|---------|
+| `bun run dev` | Hot reload development server (port 3000) |
+| `bun run build` | Compile TypeScript to dist/ |
+| `bun start` | Run compiled app (production) |
+| `bun test` | Run all tests in src/ |
+| `bun test --watch` | Watch mode tests |
+| `bun test --coverage` | Coverage report |
+| `bun run lint` | ESLint check |
+| `bun run lint:fix` | Auto-fix linting issues |
+| `bun run lint:ts` | Type check only (no emit) |
+
+## Database & Migrations
+
+### Migrations
+
+Located in `src/shared/infrastructure/database/migrations/`. Each migration has `up()` (apply) and `down()` (revert) methods.
+
+```bash
+bun run migration:generate src/shared/infrastructure/database/migrations/DescriptionCamelCase
+# Auto-generate from entity changes
+bun run migration:run    # Apply pending migrations
+bun run migration:revert # Revert last migration
+bun run migration:show   # View migration status
+```
+
+**Workflow**: Modify entity → Generate migration → Review → Test locally with `migration:run` + `migration:revert` → Commit
+
+### Seeds
+
+Initial data seeded on first run (dev only). Controlled by `src/shared/infrastructure/database/seeds/initial-seeds.ts`.
+
+```bash
+bun run seeder           # Run seeds
+bun run seeder --clean   # Drop tables and re-seed
+```
+
+### Configuration
+
+MySQL credentials from `.env`:
+- `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD`, `DB_DATABASE`
+- `DB_ROOT_USERNAME`, `DB_ROOT_PASSWORD` (for migrations/setup)
+- JWT: `JWT_SECRET`, `JWT_EXPIRES_IN`
+
+See `.env.example` for full config (S3, SMTP, rate limiting, RBAC flag).
+
+## Architecture Patterns
+
+### Repository Pattern
+
+**Repository** = translator between domain objects and database. All DB queries happen via repository methods.
+
+- **Interface** in `src/domains/{domain}/repositories/`: defines what operations exist
+- **Implementation** in `src/shared/infrastructure/repositories/`: TypeORM implementation with `toEntity()` (domain → DB) and `toDomain()` (DB → domain) converters
+- Always return domain objects, not entities
+
+See `src/shared/infrastructure/repositories/README.md` for examples (find by RUT, expiring contracts, etc.).
+
+### Dependency Injection
+
+`src/dependency-container.ts`: Instantiates all controllers, use cases, repositories. Called once at app bootstrap.
+
+For new domain: Create DI methods in the container, call from `app.ts` route setup.
+
+### Path Aliases
+
+TypeScript paths configured in `tsconfig.json`:
+- `@domains/*` → `src/domains/*`
+- `@shared/*` → `src/shared/*`
+- `@presentation/*` → `src/presentation/*`
+- `@/*` → `src/*`
+
+Use these everywhere (cleaner imports).
+
+## Key Features
+
+- **RBAC**: Role-Based Access Control (enabled via `ENABLE_RBAC=true`). Permission cache in `src/shared/infrastructure/cache/`
+- **Rate Limiting**: Express rate limiter on `/api` (configurable via `.env`)
+- **Security**: Helmet (headers), CORS (origins from `.env`), JWT (httpOnly cookies)
+- **Error Handling**: Global error handler in `src/shared/middleware/error-handler.ts` + custom error classes in `src/shared/domain/errors.ts`
+- **Logging**: Morgan for HTTP logs (disabled in tests), Winston for app logs
+- **File Upload**: Local or AWS S3, configured via `FILE_STORAGE` env var
+
+## Testing
+
+- Uses Bun's native test runner (Jest-compatible)
+- Test files colocated: `src/**/*.test.ts` or `src/**/*.spec.ts`
+- Mock repositories easily (in-memory array implementations)
+
+Example test structure:
+```typescript
+import { describe, it, expect } from 'bun:test';
+
+describe('UseCase', () => {
+  it('should do something', async () => {
+    const result = await useCase.execute({ input });
+    expect(result).toEqual(expected);
+  });
+});
+```
+
+## Health Check & API Info
+
+- `/health` → uptime, environment
+- `/api` → endpoints list
+
+## Hot Reload
+
+`bun run dev` watches `src/` for changes and restarts the server automatically.
+
+## Adding New Features
+
+1. **New domain**: Create folder in `src/domains/{domain}` with entities, repositories (interface), use-cases
+2. **Repository impl**: Add to `src/shared/infrastructure/repositories/typeorm-{domain}.repository.ts`
+3. **Controller**: Add to `src/presentation/controllers/{domain}.controller.ts`
+4. **Routes**: Add to `src/presentation/routes/{domain}.routes.ts`
+5. **DI**: Register in `src/dependency-container.ts`
+6. **App**: Mount routes in `src/app.ts` setupRoutes()
+7. **Database**: Generate migration if adding tables/columns
+
+## Debugging Tips
+
+- **TypeScript errors**: `bun run lint:ts` (type check without emit)
+- **DB connection**: Check `.env` credentials, run migrations with `migration:show`
+- **Hot reload not working**: Check file syntax (errors prevent reload)
+- **RBAC issues**: Ensure permissions cached and `ENABLE_RBAC=true`
+- **Tests failing**: Run single test with `bun test src/path/to/test.ts`
+
+## Code Quality Standards
+
+These are the standards Claude should enforce and follow when writing or reviewing code in this project.
+
+### Architecture rules
+- Business logic belongs exclusively in `domains/` — never in controllers, routes, or repositories
+- Controllers only handle HTTP: parse request, call use case, return response
+- Repository implementations only handle persistence: no business rules, no domain logic
+- Use cases do one thing — if a use case needs another use case, inject it as a dependency
+- Always use path aliases (`@domains/`, `@shared/`, `@presentation/`) — never relative `../../` imports
+
+### TypeScript rules
+- Never use `any` — use explicit types, generics, or `unknown` with type guards
+- All function parameters and return types must be explicitly typed
+- DTOs must be typed interfaces or classes, never plain objects
+- Domain errors must extend from `src/shared/domain/errors.ts`
+
+### Security rules
+- Never log passwords, JWT tokens, RUTs, or any personal data
+- Never hardcode credentials, secrets, or API keys — always use environment variables
+- Always validate and sanitize external inputs before they reach use cases
+- Sensitive endpoints must check RBAC permissions when `ENABLE_RBAC=true`
+
+### Database rules
+- Every entity change (new column, table, relation) requires a migration
+- Never modify existing migrations — create a new one
+- Repository implementations must always use `toDomain()` and `toEntity()` converters
+- Never return raw TypeORM entities outside the repository layer
+
+### Testing rules
+- New use cases must have at least one unit test
+- Test files go next to the file they test: `use-case.ts` → `use-case.test.ts`
+- Use in-memory repository mocks, never a real database in unit tests
+- New environment variables must be added to `.env.example`

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,7 @@ import { createFileShareAuthRoutes, createSharedFileRoutes } from '@presentation
 import { createCompanyRoutes } from '@presentation/routes/company.routes';
 import { createAreaRoutes } from '@presentation/routes/area.routes';
 import { createDivisionRoutes } from '@presentation/routes/division.routes';
+import { createDocumentTemplateRoutes } from '@presentation/routes/document-template.routes';
 import { DependencyContainer } from './dependency-container';
 import { runInitialSeedsIfEmpty } from '@shared/infrastructure/database/seeds/initial-seeds';
 import { RouteError } from '@shared/domain/errors';
@@ -171,6 +172,7 @@ export class App {
     const companyController = this.dependencyContainer.getCompanyController();
     const bulkTemplateController = this.dependencyContainer.getBulkTemplateController();
     const fileShareController = this.dependencyContainer.getFileShareController();
+    const documentTemplateController = this.dependencyContainer.getDocumentTemplateController();
 
     // Get use cases and repositories needed for middleware
     const checkUserCanReviewContractUseCase = this.dependencyContainer.getCheckUserCanReviewContractUseCase();
@@ -203,6 +205,7 @@ export class App {
     this.app.use('/api/files', createFileRoutes(fileController));
     this.app.use('/api/files', createFileShareAuthRoutes(fileShareController));
     this.app.use('/api/shared/files', createSharedFileRoutes(fileShareController));
+    this.app.use('/api/document-templates', createDocumentTemplateRoutes(documentTemplateController));
 
     // Auth routes
     this.app.use('/api/auth', createAuthRoutes(authController));

--- a/src/dependency-container.ts
+++ b/src/dependency-container.ts
@@ -177,6 +177,7 @@ import { TypeOrmDocumentTypeRepository } from '@shared/infrastructure/repositori
 import { TypeOrmDocumentSubtypeRepository } from '@shared/infrastructure/repositories/typeorm-document-subtype.repository';
 import { TypeOrmDocumentRepository } from '@shared/infrastructure/repositories/typeorm-document.repository';
 import { TypeOrmDocumentHistoryRepository } from '@shared/infrastructure/repositories/typeorm-document-history.repository';
+import { TypeOrmDocumentFieldValueRepository } from '@shared/infrastructure/repositories/typeorm-document-field-value.repository';
 import { TypeOrmCompanyRepository } from '@shared/infrastructure/repositories/typeorm-company.repository';
 
 import { TypeOrmPermissionRepository } from '@shared/infrastructure/repositories/typeorm-permission.repository';
@@ -209,6 +210,20 @@ import { GetFileByShareTokenUseCase } from '@domains/file-share/use-cases/get-fi
 import { TypeOrmFileShareRepository } from '@shared/infrastructure/repositories/typeorm-file-share.repository';
 import { FileShareController } from '@presentation/controllers/file-share.controller';
 
+// DocumentTemplate domain
+import { CreateDocumentTemplateUseCase } from '@domains/document-template/use-cases/create-document-template.use-case';
+import {
+  GetDocumentTemplateByIdUseCase,
+  GetAllDocumentTemplatesUseCase,
+  GetDocumentTemplateVersionsUseCase,
+} from '@domains/document-template/use-cases/get-document-template.use-case';
+import {
+  CreateNewDocumentTemplateVersionUseCase,
+  DeleteDocumentTemplateUseCase,
+} from '@domains/document-template/use-cases/update-document-template.use-case';
+import { TypeOrmDocumentTemplateRepository } from '@shared/infrastructure/repositories/typeorm-document-template.repository';
+import { DocumentTemplateController } from '@presentation/controllers/document-template.controller';
+
 export class DependencyContainer {
   // Repositories
   private userRepository!: TypeOrmUserRepository;
@@ -219,6 +234,7 @@ export class DependencyContainer {
 
   private documentRepository!: TypeOrmDocumentRepository;
   private documentHistoryRepository!: TypeOrmDocumentHistoryRepository;
+  private documentFieldValueRepository!: TypeOrmDocumentFieldValueRepository;
   private permissionRepository!: TypeOrmPermissionRepository;
   private roleRepository!: TypeOrmRoleRepository;
   private contractReviewerRepository!: TypeOrmContractReviewerRepository;
@@ -232,10 +248,19 @@ export class DependencyContainer {
   private divisionRepository!: TypeOrmDivisionRepository;
   private bulkUploadTemplateRepository!: TypeOrmBulkUploadTemplateRepository;
   private fileShareRepository!: TypeOrmFileShareRepository;
+  private documentTemplateRepository!: TypeOrmDocumentTemplateRepository;
 
   // Use Cases - BulkTemplate
   private manageBulkTemplateUseCase!: ManageBulkTemplateUseCase;
   private bulkLoadColaboratorsUseCase!: BulkLoadColaboratorsUseCase;
+
+  // Use Cases - DocumentTemplate
+  private createDocumentTemplateUseCase!: CreateDocumentTemplateUseCase;
+  private getDocumentTemplateByIdUseCase!: GetDocumentTemplateByIdUseCase;
+  private getAllDocumentTemplatesUseCase!: GetAllDocumentTemplatesUseCase;
+  private getDocumentTemplateVersionsUseCase!: GetDocumentTemplateVersionsUseCase;
+  private createNewDocumentTemplateVersionUseCase!: CreateNewDocumentTemplateVersionUseCase;
+  private deleteDocumentTemplateUseCase!: DeleteDocumentTemplateUseCase;
 
   // Use Cases - User
   private createUserUseCase!: CreateUserUseCase;
@@ -423,6 +448,7 @@ export class DependencyContainer {
   private fileController!: FileController;
   private bulkTemplateController!: BulkTemplateController;
   private fileShareController!: FileShareController;
+  private documentTemplateController!: DocumentTemplateController;
 
   // Use Cases - FileShare
   private createFileShareUseCase!: CreateFileShareUseCase;
@@ -451,6 +477,7 @@ export class DependencyContainer {
     this.divisionRepository = new TypeOrmDivisionRepository();
     this.bulkUploadTemplateRepository = new TypeOrmBulkUploadTemplateRepository();
     this.fileShareRepository = new TypeOrmFileShareRepository();
+    this.documentTemplateRepository = new TypeOrmDocumentTemplateRepository();
 
     // Initialize User use cases
     this.createUserUseCase = new CreateUserUseCase(this.userRepository, this.roleRepository, this.groupRepository);
@@ -488,12 +515,14 @@ export class DependencyContainer {
 
 
     // Initialize Document use cases
+    this.documentFieldValueRepository = new TypeOrmDocumentFieldValueRepository();
     this.createDocumentUseCase = new CreateDocumentUseCase(
       this.documentRepository,
       this.documentHistoryRepository,
       this.groupRepository,
       this.documentModelRepository,
       this.familyRepository,
+      this.documentFieldValueRepository,
     );
     this.getDocumentByIdUseCase = new GetDocumentByIdUseCase(this.documentRepository);
     this.getAllDocumentsUseCase = new GetAllDocumentsUseCase(this.documentRepository);
@@ -508,6 +537,7 @@ export class DependencyContainer {
       this.groupRepository,
       this.documentModelRepository,
       this.fileRepository,
+      this.documentFieldValueRepository,
     );
     this.deleteDocumentUseCase = new DeleteDocumentUseCase(this.documentRepository);
     this.sendToReviewDocumentUseCase = new SendToReviewDocumentUseCase(this.documentRepository, this.documentHistoryRepository);
@@ -898,6 +928,26 @@ export class DependencyContainer {
       this.bulkUploadTemplateRepository,
       this.bulkLoadColaboratorsUseCase,
     );
+
+    // Initialize DocumentTemplate use cases
+    this.createDocumentTemplateUseCase = new CreateDocumentTemplateUseCase(
+      this.documentTemplateRepository,
+      this.groupRepository,
+    );
+    this.getDocumentTemplateByIdUseCase = new GetDocumentTemplateByIdUseCase(this.documentTemplateRepository);
+    this.getAllDocumentTemplatesUseCase = new GetAllDocumentTemplatesUseCase(this.documentTemplateRepository);
+    this.getDocumentTemplateVersionsUseCase = new GetDocumentTemplateVersionsUseCase(this.documentTemplateRepository);
+    this.createNewDocumentTemplateVersionUseCase = new CreateNewDocumentTemplateVersionUseCase(this.documentTemplateRepository);
+    this.deleteDocumentTemplateUseCase = new DeleteDocumentTemplateUseCase(this.documentTemplateRepository);
+
+    this.documentTemplateController = new DocumentTemplateController(
+      this.createDocumentTemplateUseCase,
+      this.getDocumentTemplateByIdUseCase,
+      this.getAllDocumentTemplatesUseCase,
+      this.getDocumentTemplateVersionsUseCase,
+      this.createNewDocumentTemplateVersionUseCase,
+      this.deleteDocumentTemplateUseCase,
+    );
   }
 
   // Getters for controllers
@@ -1059,5 +1109,9 @@ export class DependencyContainer {
 
   public getFileShareController(): FileShareController {
     return this.fileShareController;
+  }
+
+  public getDocumentTemplateController(): DocumentTemplateController {
+    return this.documentTemplateController;
   }
 }

--- a/src/domains/document-template/entities/document-template.entity.ts
+++ b/src/domains/document-template/entities/document-template.entity.ts
@@ -3,14 +3,70 @@ import { ValidationError } from '@shared/domain/errors';
 
 export type DocumentTemplateFieldType = 'text' | 'number' | 'date' | 'select' | 'textarea';
 
-export interface DocumentTemplateField {
-  id: string;
-  name: string;
-  label: string;
-  fieldType: DocumentTemplateFieldType;
-  required: boolean;
-  order: number;
-  options?: string[];
+const VALID_FIELD_TYPES: DocumentTemplateFieldType[] = ['text', 'number', 'date', 'select', 'textarea'];
+
+export class DocumentTemplateField {
+  readonly id: string;
+  readonly name: string;
+  readonly label: string;
+  readonly fieldType: DocumentTemplateFieldType;
+  readonly required: boolean;
+  readonly order: number;
+  readonly options?: string[];
+
+  constructor(props: {
+    id: string;
+    name: string;
+    label: string;
+    fieldType: DocumentTemplateFieldType;
+    required: boolean;
+    order: number;
+    options?: string[];
+  }) {
+    this.id = props.id;
+    this.name = props.name;
+    this.label = props.label;
+    this.fieldType = props.fieldType;
+    this.required = props.required;
+    this.order = props.order;
+    this.options = props.options;
+  }
+
+  public static create(props: {
+    id: string;
+    name: string;
+    label: string;
+    fieldType: string;
+    required: boolean;
+    order: number;
+    options?: string[];
+  }): DocumentTemplateField {
+    if (!props.id?.trim()) {
+      throw new ValidationError('El id del campo es requerido');
+    }
+    if (!props.name?.trim()) {
+      throw new ValidationError('El nombre del campo es requerido');
+    }
+    if (!props.label?.trim()) {
+      throw new ValidationError('La etiqueta del campo es requerida');
+    }
+    if (!VALID_FIELD_TYPES.includes(props.fieldType as DocumentTemplateFieldType)) {
+      throw new ValidationError(`Tipo de campo inválido: ${props.fieldType}`);
+    }
+    if (!Number.isInteger(props.order) || props.order < 0) {
+      throw new ValidationError('El orden del campo debe ser un entero no negativo');
+    }
+
+    return new DocumentTemplateField({
+      id: props.id,
+      name: props.name,
+      label: props.label,
+      fieldType: props.fieldType as DocumentTemplateFieldType,
+      required: props.required,
+      order: props.order,
+      options: props.options,
+    });
+  }
 }
 
 export interface DocumentTemplateProps {
@@ -30,19 +86,19 @@ export interface DocumentTemplateProps {
 }
 
 export class DocumentTemplate {
-  id: string;
-  code: string;
-  title: string;
-  version: number;
-  documentDate: Date;
-  description: string | null;
-  fileUrl: string | null;
-  groupId: number;
-  fields: DocumentTemplateField[];
-  createdBy: string | null;
-  createdAt: Date;
-  updatedAt: Date;
-  deletedAt: Date | null;
+  readonly id: string;
+  readonly code: string;
+  readonly title: string;
+  readonly version: number;
+  readonly documentDate: Date;
+  readonly description: string | null;
+  readonly fileUrl: string | null;
+  readonly groupId: number;
+  readonly fields: DocumentTemplateField[];
+  readonly createdBy: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly deletedAt: Date | null;
 
   constructor(props: DocumentTemplateProps) {
     DocumentTemplate.validateRequired(props);
@@ -53,7 +109,7 @@ export class DocumentTemplate {
       documentDate: 'date',
       description: (v?: string) => v || null,
       fileUrl: (v?: string) => v || null,
-      fields: (v?: DocumentTemplateField[]) => v ?? [],
+      fields: (v?: DocumentTemplateField[]) => (v ?? []).map(f => DocumentTemplateField.create(f)),
       createdBy: (v?: string) => v || null,
       deletedAt: 'dateNullable',
       createdAt: 'datetime',

--- a/src/domains/document-template/entities/document-template.entity.ts
+++ b/src/domains/document-template/entities/document-template.entity.ts
@@ -1,0 +1,114 @@
+import { EntityUtils } from '@shared/utils/common';
+import { ValidationError } from '@shared/domain/errors';
+
+export type DocumentTemplateFieldType = 'text' | 'number' | 'date' | 'select' | 'textarea';
+
+export interface DocumentTemplateField {
+  id: string;
+  name: string;
+  label: string;
+  fieldType: DocumentTemplateFieldType;
+  required: boolean;
+  order: number;
+  options?: string[];
+}
+
+export interface DocumentTemplateProps {
+  id?: string;
+  code?: string;
+  title: string;
+  version?: number;
+  documentDate: Date;
+  description?: string;
+  fileUrl?: string;
+  groupId: number;
+  fields?: DocumentTemplateField[];
+  createdBy?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+  deletedAt?: Date | null;
+}
+
+export class DocumentTemplate {
+  id: string;
+  code: string;
+  title: string;
+  version: number;
+  documentDate: Date;
+  description: string | null;
+  fileUrl: string | null;
+  groupId: number;
+  fields: DocumentTemplateField[];
+  createdBy: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+
+  constructor(props: DocumentTemplateProps) {
+    DocumentTemplate.validateRequired(props);
+
+    EntityUtils.assign(this as DocumentTemplate, props, {
+      id: 'uuid',
+      version: (v?: number) => v ?? 1,
+      documentDate: 'date',
+      description: (v?: string) => v || null,
+      fileUrl: (v?: string) => v || null,
+      fields: (v?: DocumentTemplateField[]) => v ?? [],
+      createdBy: (v?: string) => v || null,
+      deletedAt: 'dateNullable',
+      createdAt: 'datetime',
+      updatedAt: 'datetime',
+    });
+  }
+
+  public static create(props: DocumentTemplateProps): DocumentTemplate {
+    return new DocumentTemplate(props);
+  }
+
+  private static validateRequired(props: DocumentTemplateProps): void {
+    if (!props.title || props.title.trim().length === 0) {
+      throw new ValidationError('El título de la plantilla es requerido');
+    }
+    if (props.title.trim().length < 2) {
+      throw new ValidationError('El título debe tener al menos 2 caracteres');
+    }
+    if (!props.documentDate) {
+      throw new ValidationError('La fecha del documento es requerida');
+    }
+    if (!props.groupId) {
+      throw new ValidationError('El ID del grupo es requerido');
+    }
+  }
+
+  public createNewVersion(props: Partial<DocumentTemplateProps>): DocumentTemplateProps {
+    return {
+      title: props.title ?? this.title,
+      version: this.version + 1,
+      documentDate: props.documentDate ?? this.documentDate,
+      description: props.description ?? this.description ?? undefined,
+      fileUrl: props.fileUrl ?? this.fileUrl ?? undefined,
+      groupId: this.groupId,
+      fields: props.fields ?? this.fields,
+      createdBy: props.createdBy ?? this.createdBy ?? undefined,
+      code: this.code,
+    };
+  }
+
+  public toJSON(): Record<string, unknown> {
+    return {
+      id: this.id,
+      code: this.code,
+      title: this.title,
+      version: this.version,
+      documentDate: this.documentDate,
+      description: this.description,
+      fileUrl: this.fileUrl,
+      groupId: this.groupId,
+      fields: this.fields,
+      createdBy: this.createdBy,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+      deletedAt: this.deletedAt,
+    };
+  }
+}

--- a/src/domains/document-template/repositories/document-template.repository.interface.ts
+++ b/src/domains/document-template/repositories/document-template.repository.interface.ts
@@ -1,0 +1,11 @@
+import { DocumentTemplate } from '../entities/document-template.entity';
+
+export interface IDocumentTemplateRepository {
+  save(template: DocumentTemplate): Promise<DocumentTemplate>;
+  findById(id: string): Promise<DocumentTemplate | null>;
+  findAll(groupId?: number): Promise<DocumentTemplate[]>;
+  findByCode(code: string): Promise<DocumentTemplate[]>;
+  findLatestByCode(code: string, groupId: number): Promise<DocumentTemplate | null>;
+  delete(id: string): Promise<void>;
+  getNextCode(): Promise<string>;
+}

--- a/src/domains/document-template/use-cases/create-document-template.use-case.ts
+++ b/src/domains/document-template/use-cases/create-document-template.use-case.ts
@@ -1,0 +1,45 @@
+import { IDocumentTemplateRepository } from '../repositories/document-template.repository.interface';
+import { DocumentTemplate, DocumentTemplateField, DocumentTemplateProps } from '../entities/document-template.entity';
+import { ValidationError } from '@shared/domain/errors';
+import { GroupRepository } from '@domains/group/repositories/group.repository';
+
+export interface CreateDocumentTemplateRequest {
+  title: string;
+  documentDate: Date;
+  description?: string;
+  fileUrl?: string;
+  groupId: number;
+  fields?: DocumentTemplateField[];
+  createdBy?: string;
+}
+
+export class CreateDocumentTemplateUseCase {
+  constructor(
+    private readonly documentTemplateRepository: IDocumentTemplateRepository,
+    private readonly groupRepository: GroupRepository,
+  ) {}
+
+  public async execute(request: CreateDocumentTemplateRequest): Promise<DocumentTemplate> {
+    const group = await this.groupRepository.findById(request.groupId);
+    if (!group) {
+      throw new ValidationError('Grupo no encontrado', 'groupId');
+    }
+
+    const code = await this.documentTemplateRepository.getNextCode();
+
+    const props: DocumentTemplateProps = {
+      title: request.title,
+      code,
+      version: 1,
+      documentDate: request.documentDate,
+      description: request.description,
+      fileUrl: request.fileUrl,
+      groupId: request.groupId,
+      fields: request.fields ?? [],
+      createdBy: request.createdBy,
+    };
+
+    const template = DocumentTemplate.create(props);
+    return this.documentTemplateRepository.save(template);
+  }
+}

--- a/src/domains/document-template/use-cases/get-document-template.use-case.ts
+++ b/src/domains/document-template/use-cases/get-document-template.use-case.ts
@@ -1,0 +1,31 @@
+import { IDocumentTemplateRepository } from '../repositories/document-template.repository.interface';
+import { DocumentTemplate } from '../entities/document-template.entity';
+import { NotFoundError } from '@shared/domain/errors';
+
+export class GetDocumentTemplateByIdUseCase {
+  constructor(private readonly documentTemplateRepository: IDocumentTemplateRepository) {}
+
+  public async execute(id: string): Promise<DocumentTemplate> {
+    const template = await this.documentTemplateRepository.findById(id);
+    if (!template) {
+      throw new NotFoundError('Plantilla de documento no encontrada');
+    }
+    return template;
+  }
+}
+
+export class GetAllDocumentTemplatesUseCase {
+  constructor(private readonly documentTemplateRepository: IDocumentTemplateRepository) {}
+
+  public async execute(groupId?: number): Promise<DocumentTemplate[]> {
+    return this.documentTemplateRepository.findAll(groupId);
+  }
+}
+
+export class GetDocumentTemplateVersionsUseCase {
+  constructor(private readonly documentTemplateRepository: IDocumentTemplateRepository) {}
+
+  public async execute(code: string): Promise<DocumentTemplate[]> {
+    return this.documentTemplateRepository.findByCode(code);
+  }
+}

--- a/src/domains/document-template/use-cases/update-document-template.use-case.ts
+++ b/src/domains/document-template/use-cases/update-document-template.use-case.ts
@@ -1,0 +1,47 @@
+import { IDocumentTemplateRepository } from '../repositories/document-template.repository.interface';
+import { DocumentTemplate, DocumentTemplateField } from '../entities/document-template.entity';
+import { NotFoundError } from '@shared/domain/errors';
+
+export interface CreateNewVersionRequest {
+  title?: string;
+  documentDate?: Date;
+  description?: string;
+  fileUrl?: string;
+  fields?: DocumentTemplateField[];
+  createdBy?: string;
+}
+
+export class CreateNewDocumentTemplateVersionUseCase {
+  constructor(private readonly documentTemplateRepository: IDocumentTemplateRepository) {}
+
+  public async execute(id: string, request: CreateNewVersionRequest): Promise<DocumentTemplate> {
+    const existing = await this.documentTemplateRepository.findById(id);
+    if (!existing) {
+      throw new NotFoundError('Plantilla de documento no encontrada');
+    }
+
+    // Get latest version for this code to compute next version number
+    const latestVersion = await this.documentTemplateRepository.findLatestByCode(existing.code, existing.groupId);
+    const nextVersion = (latestVersion?.version ?? existing.version) + 1;
+
+    const newVersionProps = existing.createNewVersion({
+      ...request,
+      version: nextVersion,
+    } as any);
+
+    const newTemplate = DocumentTemplate.create({ ...newVersionProps, version: nextVersion });
+    return this.documentTemplateRepository.save(newTemplate);
+  }
+}
+
+export class DeleteDocumentTemplateUseCase {
+  constructor(private readonly documentTemplateRepository: IDocumentTemplateRepository) {}
+
+  public async execute(id: string): Promise<void> {
+    const existing = await this.documentTemplateRepository.findById(id);
+    if (!existing) {
+      throw new NotFoundError('Plantilla de documento no encontrada');
+    }
+    await this.documentTemplateRepository.delete(id);
+  }
+}

--- a/src/domains/document-template/use-cases/update-document-template.use-case.ts
+++ b/src/domains/document-template/use-cases/update-document-template.use-case.ts
@@ -24,10 +24,7 @@ export class CreateNewDocumentTemplateVersionUseCase {
     const latestVersion = await this.documentTemplateRepository.findLatestByCode(existing.code, existing.groupId);
     const nextVersion = (latestVersion?.version ?? existing.version) + 1;
 
-    const newVersionProps = existing.createNewVersion({
-      ...request,
-      version: nextVersion,
-    } as any);
+    const newVersionProps = existing.createNewVersion(request);
 
     const newTemplate = DocumentTemplate.create({ ...newVersionProps, version: nextVersion });
     return this.documentTemplateRepository.save(newTemplate);

--- a/src/domains/document/entities/document.entity.ts
+++ b/src/domains/document/entities/document.entity.ts
@@ -4,6 +4,11 @@ import { DateTimeUtils, DateUtils } from '@shared/utils/date';
 import { parseEnum } from '@shared/utils/objects';
 import { DocumentStatus } from '../value-objects/document-enums';
 
+export interface DocumentFieldValue {
+  fieldName: string;
+  fieldValue: string | null;
+}
+
 export interface DocumentProps {
   id?: string;
   documentModelId: string;
@@ -25,6 +30,8 @@ export interface DocumentProps {
   deletedBy?: string | null;
   createdAt?: Date;
   updatedAt?: Date;
+  templateId?: string | null;
+  fieldValues?: DocumentFieldValue[];
 
   // Read-only properties from DocumentModel (for display)
   documentTypeId?: string;
@@ -57,6 +64,8 @@ export class Document {
   deletedBy: string | null;
   createdAt: Date;
   updatedAt: Date;
+  templateId: string | null;
+  fieldValues: DocumentFieldValue[];
 
   // Read-only properties
   documentTypeId?: string;
@@ -85,6 +94,8 @@ export class Document {
       createdAt: 'datetime',
       updatedAt: 'datetime',
       colaboratorIds: (ids?: string[]) => ids ?? [],
+      templateId: (id?: string | null) => id || null,
+      fieldValues: (vals?: DocumentFieldValue[]) => vals ?? [],
     });
 
     // Assign read-only props

--- a/src/domains/document/repositories/document-field-value.repository.ts
+++ b/src/domains/document/repositories/document-field-value.repository.ts
@@ -1,0 +1,7 @@
+import { DocumentFieldValue } from '../entities/document.entity';
+
+export interface DocumentFieldValueRepository {
+  saveMany(documentId: string, fieldValues: DocumentFieldValue[]): Promise<void>;
+  findByDocumentId(documentId: string): Promise<DocumentFieldValue[]>;
+  deleteByDocumentId(documentId: string): Promise<void>;
+}

--- a/src/domains/document/use-cases/create-document.use-case.ts
+++ b/src/domains/document/use-cases/create-document.use-case.ts
@@ -1,6 +1,7 @@
 import { DocumentRepository } from '../repositories/document.repository';
 import { DocumentHistoryRepository } from '../repositories/document-history.repository';
-import { Document, DocumentProps } from '../entities/document.entity';
+import { DocumentFieldValueRepository } from '../repositories/document-field-value.repository';
+import { Document, DocumentProps, DocumentFieldValue } from '../entities/document.entity';
 import { DocumentHistoryProps } from '../entities/document-history.entity';
 import { DocumentAction } from '../value-objects/document-enums';
 import { ValidationError } from '@shared/domain/errors';
@@ -20,6 +21,8 @@ export interface CreateDocumentRequest {
   requiredColaboratorsCount?: number;
   createdBy?: string;
   comment?: string;
+  templateId?: string;
+  fieldValues?: DocumentFieldValue[];
 }
 
 export class CreateDocumentUseCase {
@@ -29,6 +32,7 @@ export class CreateDocumentUseCase {
     private readonly groupRepository: GroupRepository,
     private readonly documentModelRepository: IDocumentModelRepository,
     private readonly familyRepository: IFamilyRepository,
+    private readonly documentFieldValueRepository?: DocumentFieldValueRepository,
   ) {}
 
   public async execute(request: CreateDocumentRequest): Promise<Document> {
@@ -84,12 +88,18 @@ export class CreateDocumentUseCase {
       groupId: request.groupId,
       requiredColaboratorsCount: request.requiredColaboratorsCount,
       createdBy: request.createdBy,
+      templateId: request.templateId,
     };
 
     const document = Document.create(documentProps);
 
     // Guardando documento
     const savedDocument = await this.documentRepository.save(document);
+
+    // Guardando valores de campos de plantilla
+    if (this.documentFieldValueRepository && request.fieldValues && request.fieldValues.length > 0) {
+      await this.documentFieldValueRepository.saveMany(savedDocument.id, request.fieldValues);
+    }
 
     // Creando entrada de historial cuando el contexto del usuario está disponible
     if (request.createdBy && request.createdBy !== 'system') {

--- a/src/domains/document/use-cases/update-document.use-case.ts
+++ b/src/domains/document/use-cases/update-document.use-case.ts
@@ -1,6 +1,7 @@
 import { DocumentRepository } from '../repositories/document.repository';
 import { DocumentHistoryRepository } from '../repositories/document-history.repository';
-import { Document } from '../entities/document.entity';
+import { DocumentFieldValueRepository } from '../repositories/document-field-value.repository';
+import { Document, DocumentFieldValue } from '../entities/document.entity';
 import { DocumentHistoryProps } from '../entities/document-history.entity';
 import { DocumentAction } from '../value-objects/document-enums';
 import { NotFoundError, ValidationError } from '@shared/domain/errors';
@@ -21,6 +22,8 @@ export interface UpdateDocumentRequest {
   requiredColaboratorsCount?: number;
   updatedBy?: string;
   comment?: string;
+  templateId?: string;
+  fieldValues?: DocumentFieldValue[];
 }
 
 export class UpdateDocumentUseCase {
@@ -30,6 +33,7 @@ export class UpdateDocumentUseCase {
     private readonly groupRepository: GroupRepository,
     private readonly documentModelRepository: IDocumentModelRepository,
     private readonly fileRepository: TypeOrmFileRepository,
+    private readonly documentFieldValueRepository?: DocumentFieldValueRepository,
   ) {}
 
   public async execute(id: string, request: UpdateDocumentRequest): Promise<Document> {
@@ -136,6 +140,14 @@ export class UpdateDocumentUseCase {
 
     // Actualizar documento
     const updatedDocument = await this.documentRepository.update(document);
+
+    // Actualizar valores de campos de plantilla si se proporcionaron
+    if (this.documentFieldValueRepository && request.fieldValues !== undefined) {
+      await this.documentFieldValueRepository.deleteByDocumentId(updatedDocument.id);
+      if (request.fieldValues.length > 0) {
+        await this.documentFieldValueRepository.saveMany(updatedDocument.id, request.fieldValues);
+      }
+    }
 
     // Crear entrada de historial
     const historyProps: DocumentHistoryProps = {

--- a/src/presentation/controllers/document-model.controller.ts
+++ b/src/presentation/controllers/document-model.controller.ts
@@ -24,7 +24,7 @@ export class DocumentModelController {
   public createDocumentModel = asyncHandler(async (req: Request, res: Response) => {
     const request = {
       ...req.body,
-      groupId: req.body.groupId || req.auth?.groupId,
+      groupId: req.auth?.groupId ?? req.body.groupId,
     };
     const documentModel = await this.createDocumentModelUseCase.execute(request);
     res.status(201).json({

--- a/src/presentation/controllers/document-template.controller.ts
+++ b/src/presentation/controllers/document-template.controller.ts
@@ -1,0 +1,89 @@
+import { Request, Response } from 'express';
+import { CreateDocumentTemplateUseCase } from '@domains/document-template/use-cases/create-document-template.use-case';
+import {
+  GetDocumentTemplateByIdUseCase,
+  GetAllDocumentTemplatesUseCase,
+  GetDocumentTemplateVersionsUseCase,
+} from '@domains/document-template/use-cases/get-document-template.use-case';
+import {
+  CreateNewDocumentTemplateVersionUseCase,
+  DeleteDocumentTemplateUseCase,
+} from '@domains/document-template/use-cases/update-document-template.use-case';
+import { asyncHandler } from '@shared/middleware/validation';
+import { parseNum } from '@shared/utils/numbers';
+
+export class DocumentTemplateController {
+  constructor(
+    private readonly createDocumentTemplateUseCase: CreateDocumentTemplateUseCase,
+    private readonly getDocumentTemplateByIdUseCase: GetDocumentTemplateByIdUseCase,
+    private readonly getAllDocumentTemplatesUseCase: GetAllDocumentTemplatesUseCase,
+    private readonly getDocumentTemplateVersionsUseCase: GetDocumentTemplateVersionsUseCase,
+    private readonly createNewVersionUseCase: CreateNewDocumentTemplateVersionUseCase,
+    private readonly deleteDocumentTemplateUseCase: DeleteDocumentTemplateUseCase,
+  ) {}
+
+  public createDocumentTemplate = asyncHandler(async (req: Request, res: Response) => {
+    const groupId = req.body.groupId || req.auth?.groupId;
+    const template = await this.createDocumentTemplateUseCase.execute({
+      ...req.body,
+      groupId,
+      createdBy: req.auth?.userId,
+    });
+    res.status(201).json({
+      success: true,
+      data: template.toJSON(),
+      message: 'Plantilla de documento creada exitosamente',
+    });
+  });
+
+  public getAllDocumentTemplates = asyncHandler(async (req: Request, res: Response) => {
+    const groupId = parseNum(req.query.groupId) || req.auth?.groupId;
+    const templates = await this.getAllDocumentTemplatesUseCase.execute(groupId);
+    res.status(200).json({
+      success: true,
+      data: templates.map(t => t.toJSON()),
+      count: templates.length,
+    });
+  });
+
+  public getDocumentTemplateById = asyncHandler(async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const template = await this.getDocumentTemplateByIdUseCase.execute(id);
+    res.status(200).json({
+      success: true,
+      data: template.toJSON(),
+    });
+  });
+
+  public getDocumentTemplateVersions = asyncHandler(async (req: Request, res: Response) => {
+    const { code } = req.params;
+    const versions = await this.getDocumentTemplateVersionsUseCase.execute(code);
+    res.status(200).json({
+      success: true,
+      data: versions.map(t => t.toJSON()),
+      count: versions.length,
+    });
+  });
+
+  public createNewVersion = asyncHandler(async (req: Request, res: Response) => {
+    const { id } = req.params;
+    const template = await this.createNewVersionUseCase.execute(id, {
+      ...req.body,
+      createdBy: req.auth?.userId,
+    });
+    res.status(201).json({
+      success: true,
+      data: template.toJSON(),
+      message: 'Nueva versión de plantilla creada exitosamente',
+    });
+  });
+
+  public deleteDocumentTemplate = asyncHandler(async (req: Request, res: Response) => {
+    const { id } = req.params;
+    await this.deleteDocumentTemplateUseCase.execute(id);
+    res.status(200).json({
+      success: true,
+      message: 'Plantilla de documento eliminada exitosamente',
+    });
+  });
+}

--- a/src/presentation/controllers/document-template.controller.ts
+++ b/src/presentation/controllers/document-template.controller.ts
@@ -23,7 +23,7 @@ export class DocumentTemplateController {
   ) {}
 
   public createDocumentTemplate = asyncHandler(async (req: Request, res: Response) => {
-    const groupId = req.body.groupId || req.auth?.groupId;
+    const groupId = req.auth?.groupId ?? req.body.groupId;
     const template = await this.createDocumentTemplateUseCase.execute({
       ...req.body,
       groupId,

--- a/src/presentation/controllers/document.controller.ts
+++ b/src/presentation/controllers/document.controller.ts
@@ -102,6 +102,8 @@ export class DocumentController {
       groupId: dto.groupId,
       requiredColaboratorsCount: dto.requiredColaboratorsCount,
       createdBy: req.auth.user?.id,
+      templateId: dto.templateId,
+      fieldValues: dto.fieldValues,
     });
 
     res.status(201).json({
@@ -244,6 +246,8 @@ export class DocumentController {
       requiredColaboratorsCount: dto.requiredColaboratorsCount,
       updatedBy: req.auth.user?.id,
       comment: dto.comment,
+      templateId: dto.templateId,
+      fieldValues: dto.fieldValues,
     });
 
     res.status(200).json({

--- a/src/presentation/dto/document/create-document.dto.ts
+++ b/src/presentation/dto/document/create-document.dto.ts
@@ -1,3 +1,8 @@
+export interface DocumentFieldValueDto {
+  fieldName: string;
+  fieldValue: string | null;
+}
+
 export interface CreateDocumentDto {
   documentModelId: string;
   colaboratorIds: string[];
@@ -8,4 +13,6 @@ export interface CreateDocumentDto {
   documentUrl?: string;
   groupId: number;
   requiredColaboratorsCount?: number;
+  templateId?: string;
+  fieldValues?: DocumentFieldValueDto[];
 }

--- a/src/presentation/dto/document/update-document.dto.ts
+++ b/src/presentation/dto/document/update-document.dto.ts
@@ -1,3 +1,5 @@
+import { DocumentFieldValueDto } from './create-document.dto';
+
 export interface UpdateDocumentDto {
   documentModelId?: string;
   colaboratorIds?: string[];
@@ -10,4 +12,6 @@ export interface UpdateDocumentDto {
   comment?: string;
   groupId?: number;
   requiredColaboratorsCount?: number;
+  templateId?: string;
+  fieldValues?: DocumentFieldValueDto[];
 }

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -390,7 +390,7 @@ const documentTemplateFieldSchema = Joi.object({
 
 export const createDocumentTemplateSchema = Joi.object({
   title: Joi.string().min(2).max(255).required(),
-  documentDate: Joi.date().iso().required(),
+  documentDate: Joi.string().isoDate().required(),
   description: Joi.string().max(2000).optional().allow(''),
   groupId: Joi.number().integer().positive().required(),
   fields: Joi.array().items(documentTemplateFieldSchema).optional().default([]),
@@ -398,7 +398,7 @@ export const createDocumentTemplateSchema = Joi.object({
 
 export const createDocumentTemplateVersionSchema = Joi.object({
   title: Joi.string().min(2).max(255).optional(),
-  documentDate: Joi.date().iso().optional(),
+  documentDate: Joi.string().isoDate().optional(),
   description: Joi.string().max(2000).optional().allow(''),
   fields: Joi.array().items(documentTemplateFieldSchema).optional(),
 }).min(1);

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -377,3 +377,28 @@ export const updateDocumentModelSchema = Joi.object({
   requiredForColaborator: Joi.boolean().optional(),
   requiredExpirationDate: Joi.boolean().optional(),
 }).min(1);
+
+const documentTemplateFieldSchema = Joi.object({
+  id: Joi.string().required(),
+  name: Joi.string().min(1).max(100).required(),
+  label: Joi.string().min(1).max(200).required(),
+  fieldType: Joi.string().valid('text', 'number', 'date', 'select', 'textarea').required(),
+  required: Joi.boolean().required(),
+  order: Joi.number().integer().min(0).required(),
+  options: Joi.array().items(Joi.string()).optional(),
+});
+
+export const createDocumentTemplateSchema = Joi.object({
+  title: Joi.string().min(2).max(255).required(),
+  documentDate: Joi.date().iso().required(),
+  description: Joi.string().max(2000).optional().allow(''),
+  groupId: Joi.number().integer().positive().required(),
+  fields: Joi.array().items(documentTemplateFieldSchema).optional().default([]),
+});
+
+export const createDocumentTemplateVersionSchema = Joi.object({
+  title: Joi.string().min(2).max(255).optional(),
+  documentDate: Joi.date().iso().optional(),
+  description: Joi.string().max(2000).optional().allow(''),
+  fields: Joi.array().items(documentTemplateFieldSchema).optional(),
+}).min(1);

--- a/src/presentation/dto/validation-schemas.ts
+++ b/src/presentation/dto/validation-schemas.ts
@@ -392,7 +392,7 @@ export const createDocumentTemplateSchema = Joi.object({
   title: Joi.string().min(2).max(255).required(),
   documentDate: Joi.string().isoDate().required(),
   description: Joi.string().max(2000).optional().allow(''),
-  groupId: Joi.number().integer().positive().required(),
+  groupId: Joi.number().integer().positive().optional(),
   fields: Joi.array().items(documentTemplateFieldSchema).optional().default([]),
 });
 

--- a/src/presentation/routes/document-template.routes.ts
+++ b/src/presentation/routes/document-template.routes.ts
@@ -1,0 +1,60 @@
+import { Router } from 'express';
+import { DocumentTemplateController } from '../controllers/document-template.controller';
+import { validateRequest } from '@shared/middleware/validation';
+import { createDocumentTemplateSchema, createDocumentTemplateVersionSchema } from '../dto/validation-schemas';
+import { auth } from '@shared/middleware/auth.middleware';
+import { authorize } from '@shared/middleware/authorize.middleware';
+import { assignGroup, getByGroup } from '@shared/middleware/group.middleware';
+
+export const createDocumentTemplateRoutes = (controller: DocumentTemplateController): Router => {
+  const router = Router();
+  router.use(auth);
+
+  // POST /api/document-templates - Create a new document template
+  router.post(
+    '/',
+    authorize('document-template:create'),
+    assignGroup(),
+    validateRequest(createDocumentTemplateSchema),
+    controller.createDocumentTemplate,
+  );
+
+  // GET /api/document-templates - Get all document templates
+  router.get(
+    '/',
+    authorize('document-template:read'),
+    getByGroup(),
+    controller.getAllDocumentTemplates,
+  );
+
+  // GET /api/document-templates/versions/:code - Get all versions by code
+  router.get(
+    '/versions/:code',
+    authorize('document-template:read'),
+    controller.getDocumentTemplateVersions,
+  );
+
+  // GET /api/document-templates/:id - Get document template by ID
+  router.get(
+    '/:id',
+    authorize('document-template:read'),
+    controller.getDocumentTemplateById,
+  );
+
+  // POST /api/document-templates/:id/version - Create new version
+  router.post(
+    '/:id/version',
+    authorize('document-template:update'),
+    validateRequest(createDocumentTemplateVersionSchema),
+    controller.createNewVersion,
+  );
+
+  // DELETE /api/document-templates/:id - Delete document template
+  router.delete(
+    '/:id',
+    authorize('document-template:delete'),
+    controller.deleteDocumentTemplate,
+  );
+
+  return router;
+};

--- a/src/shared/infrastructure/database/entities/document-field-value.entity.ts
+++ b/src/shared/infrastructure/database/entities/document-field-value.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { DocumentEntity } from './document.entity';
+
+@Entity('document_field_values')
+@Index('IDX_document_field_values_document_id', ['documentId'])
+@Index('IDX_document_field_values_field_name', ['fieldName'])
+@Index('IDX_document_field_values_document_field', ['documentId', 'fieldName'], { unique: true })
+export class DocumentFieldValueEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ name: 'document_id', type: 'varchar', length: 36 })
+  documentId!: string;
+
+  @ManyToOne(() => DocumentEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'document_id' })
+  document!: DocumentEntity;
+
+  @Column({ name: 'field_name', type: 'varchar', length: 100 })
+  fieldName!: string;
+
+  @Column({ name: 'field_value', type: 'text', nullable: true })
+  fieldValue?: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+}

--- a/src/shared/infrastructure/database/entities/document-template.entity.ts
+++ b/src/shared/infrastructure/database/entities/document-template.entity.ts
@@ -14,13 +14,14 @@ import { UserEntity } from './user.entity';
 
 @Entity('document_templates')
 @Index('IDX_document_templates_code', ['code'])
+@Index('IDX_document_templates_code_version', ['code', 'version'], { unique: true })
 @Index('IDX_document_templates_group_id', ['groupId'])
 @Index('IDX_document_templates_deleted_at', ['deletedAt'])
 export class DocumentTemplateEntity {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
-  @Column({ type: 'varchar', length: 20, unique: true })
+  @Column({ type: 'varchar', length: 20 })
   code!: string;
 
   @Column({ type: 'varchar', length: 255 })

--- a/src/shared/infrastructure/database/entities/document-template.entity.ts
+++ b/src/shared/infrastructure/database/entities/document-template.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { GroupEntity } from './group.entity';
+import { UserEntity } from './user.entity';
+
+@Entity('document_templates')
+@Index('IDX_document_templates_code', ['code'])
+@Index('IDX_document_templates_group_id', ['groupId'])
+@Index('IDX_document_templates_deleted_at', ['deletedAt'])
+export class DocumentTemplateEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 20, unique: true })
+  code!: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  title!: string;
+
+  @Column({ type: 'int', default: 1 })
+  version!: number;
+
+  @Column({ name: 'document_date', type: 'date' })
+  documentDate!: Date;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ name: 'file_url', type: 'varchar', length: 500, nullable: true })
+  fileUrl?: string;
+
+  @Column({ name: 'group_id', type: 'int' })
+  groupId!: number;
+
+  @Column({ type: 'text', nullable: true, name: 'fields_json' })
+  fieldsJson?: string;
+
+  @Column({ name: 'created_by', type: 'varchar', length: 36, nullable: true })
+  createdBy?: string;
+
+  @ManyToOne(() => GroupEntity)
+  @JoinColumn({ name: 'group_id' })
+  group?: GroupEntity;
+
+  @ManyToOne(() => UserEntity, { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'created_by' })
+  creator?: UserEntity;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt!: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
+  deletedAt?: Date;
+}

--- a/src/shared/infrastructure/database/entities/document.entity.ts
+++ b/src/shared/infrastructure/database/entities/document.entity.ts
@@ -15,6 +15,7 @@ import { DocumentModelEntity } from './document-model.entity';
 import { ColaboratorEntity } from './colaborators.entity';
 import { ContractEntity } from './contract.entity';
 import { UserEntity } from './user.entity';
+import { DocumentTemplateEntity } from './document-template.entity';
 
 @Entity('documents')
 @Index('IDX_documents_status', ['status'])
@@ -77,6 +78,13 @@ export class DocumentEntity {
   @ManyToOne(() => UserEntity, { onDelete: 'RESTRICT' })
   @JoinColumn({ name: 'created_by' })
   creator?: UserEntity;
+
+  @Column({ name: 'template_id', type: 'varchar', length: 36, nullable: true })
+  templateId?: string;
+
+  @ManyToOne(() => DocumentTemplateEntity, { onDelete: 'SET NULL', nullable: true })
+  @JoinColumn({ name: 'template_id' })
+  template?: DocumentTemplateEntity;
 
   @Column({ type: 'text', nullable: true })
   comment?: string;

--- a/src/shared/infrastructure/database/entities/index.ts
+++ b/src/shared/infrastructure/database/entities/index.ts
@@ -19,3 +19,5 @@ export { ContractSubcontractEntity } from './contract-subcontract.entity';
 export { DocumentHistoryEntity } from './document-history.entity';
 export { BulkUploadTemplateEntity } from './bulk-upload-template.entity';
 export { FileShareEntity } from './file-share.entity';
+export { DocumentTemplateEntity } from './document-template.entity';
+export { DocumentFieldValueEntity } from './document-field-value.entity';

--- a/src/shared/infrastructure/database/migrations/1777599890203-CreateDocumentTemplatesTable.ts
+++ b/src/shared/infrastructure/database/migrations/1777599890203-CreateDocumentTemplatesTable.ts
@@ -1,0 +1,124 @@
+import { Table, TableForeignKey, TableIndex } from 'typeorm';
+import { ImprovedRunner, IQueryRunner } from '../runner';
+
+export class CreateDocumentTemplatesTable1777599890203 extends ImprovedRunner {
+  public async onUp(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'document_templates',
+      columns: [
+        {
+          name: 'id',
+          type: 'varchar',
+          length: '36',
+          isPrimary: true,
+          generationStrategy: 'uuid',
+        },
+        {
+          name: 'code',
+          type: 'varchar',
+          length: '20',
+          isNullable: false,
+          isUnique: true,
+        },
+        {
+          name: 'title',
+          type: 'varchar',
+          length: '255',
+          isNullable: false,
+        },
+        {
+          name: 'version',
+          type: 'int',
+          default: 1,
+          isNullable: false,
+        },
+        {
+          name: 'document_date',
+          type: 'date',
+          isNullable: false,
+        },
+        {
+          name: 'description',
+          type: 'text',
+          isNullable: true,
+        },
+        {
+          name: 'file_url',
+          type: 'varchar',
+          length: '500',
+          isNullable: true,
+        },
+        {
+          name: 'group_id',
+          type: 'int',
+          isNullable: false,
+        },
+        {
+          name: 'fields_json',
+          type: 'text',
+          isNullable: true,
+        },
+        {
+          name: 'created_by',
+          type: 'varchar',
+          length: '36',
+          isNullable: true,
+        },
+        {
+          name: 'created_at',
+          type: 'timestamp',
+          default: 'CURRENT_TIMESTAMP',
+          isNullable: false,
+        },
+        {
+          name: 'updated_at',
+          type: 'timestamp',
+          default: 'CURRENT_TIMESTAMP',
+          onUpdate: 'CURRENT_TIMESTAMP',
+          isNullable: false,
+        },
+        {
+          name: 'deleted_at',
+          type: 'timestamp',
+          isNullable: true,
+        },
+      ],
+    }));
+
+    await queryRunner.createIndex('document_templates', new TableIndex({
+      name: 'IDX_document_templates_code',
+      columnNames: ['code'],
+    }));
+
+    await queryRunner.createIndex('document_templates', new TableIndex({
+      name: 'IDX_document_templates_group_id',
+      columnNames: ['group_id'],
+    }));
+
+    await queryRunner.createIndex('document_templates', new TableIndex({
+      name: 'IDX_document_templates_deleted_at',
+      columnNames: ['deleted_at'],
+    }));
+
+    await queryRunner.createForeignKey('document_templates', new TableForeignKey({
+      name: 'FK_document_templates_group',
+      columnNames: ['group_id'],
+      referencedTableName: 'groups',
+      referencedColumnNames: ['id'],
+      onDelete: 'RESTRICT',
+    }));
+
+    await queryRunner.createForeignKey('document_templates', new TableForeignKey({
+      name: 'FK_document_templates_created_by',
+      columnNames: ['created_by'],
+      referencedTableName: 'users',
+      referencedColumnNames: ['id'],
+      onDelete: 'SET NULL',
+    }));
+  }
+
+  public async onDown(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.dropTable('document_templates');
+  }
+}
+

--- a/src/shared/infrastructure/database/migrations/1777927540737-AddTemplateIdToDocuments.ts
+++ b/src/shared/infrastructure/database/migrations/1777927540737-AddTemplateIdToDocuments.ts
@@ -1,0 +1,33 @@
+import { TableColumn, TableForeignKey, TableIndex } from 'typeorm';
+import { ImprovedRunner, IQueryRunner } from '../runner';
+
+export class AddTemplateIdToDocuments1777927540737 extends ImprovedRunner {
+  public async onUp(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.addColumn('documents', new TableColumn({
+      name: 'template_id',
+      type: 'varchar',
+      length: '36',
+      isNullable: true,
+    }));
+
+    await queryRunner.createIndex('documents', new TableIndex({
+      name: 'IDX_documents_template_id',
+      columnNames: ['template_id'],
+    }));
+
+    await queryRunner.createForeignKey('documents', new TableForeignKey({
+      name: 'FK_documents_template_id',
+      columnNames: ['template_id'],
+      referencedTableName: 'document_templates',
+      referencedColumnNames: ['id'],
+      onDelete: 'SET NULL',
+    }));
+  }
+
+  public async onDown(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('documents', 'FK_documents_template_id');
+    await queryRunner.dropIndex('documents', 'IDX_documents_template_id');
+    await queryRunner.dropColumn('documents', 'template_id');
+  }
+}
+

--- a/src/shared/infrastructure/database/migrations/1777927611125-CreateDocumentFieldValuesTable.ts
+++ b/src/shared/infrastructure/database/migrations/1777927611125-CreateDocumentFieldValuesTable.ts
@@ -1,0 +1,78 @@
+import { Table, TableForeignKey, TableIndex } from 'typeorm';
+import { ImprovedRunner, IQueryRunner } from '../runner';
+
+export class CreateDocumentFieldValuesTable1777927611125 extends ImprovedRunner {
+  public async onUp(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.createTable(new Table({
+      name: 'document_field_values',
+      columns: [
+        {
+          name: 'id',
+          type: 'varchar',
+          length: '36',
+          isPrimary: true,
+          generationStrategy: 'uuid',
+        },
+        {
+          name: 'document_id',
+          type: 'varchar',
+          length: '36',
+          isNullable: false,
+        },
+        {
+          name: 'field_name',
+          type: 'varchar',
+          length: '100',
+          isNullable: false,
+        },
+        {
+          name: 'field_value',
+          type: 'text',
+          isNullable: true,
+        },
+        {
+          name: 'created_at',
+          type: 'timestamp',
+          default: 'CURRENT_TIMESTAMP',
+          isNullable: false,
+        },
+        {
+          name: 'updated_at',
+          type: 'timestamp',
+          default: 'CURRENT_TIMESTAMP',
+          onUpdate: 'CURRENT_TIMESTAMP',
+          isNullable: false,
+        },
+      ],
+    }));
+
+    await queryRunner.createIndex('document_field_values', new TableIndex({
+      name: 'IDX_document_field_values_document_id',
+      columnNames: ['document_id'],
+    }));
+
+    await queryRunner.createIndex('document_field_values', new TableIndex({
+      name: 'IDX_document_field_values_field_name',
+      columnNames: ['field_name'],
+    }));
+
+    await queryRunner.createIndex('document_field_values', new TableIndex({
+      name: 'IDX_document_field_values_document_field',
+      columnNames: ['document_id', 'field_name'],
+      isUnique: true,
+    }));
+
+    await queryRunner.createForeignKey('document_field_values', new TableForeignKey({
+      name: 'FK_document_field_values_document',
+      columnNames: ['document_id'],
+      referencedTableName: 'documents',
+      referencedColumnNames: ['id'],
+      onDelete: 'CASCADE',
+    }));
+  }
+
+  public async onDown(queryRunner: IQueryRunner): Promise<void> {
+    await queryRunner.dropTable('document_field_values');
+  }
+}
+

--- a/src/shared/infrastructure/database/migrations/1778095709242-FixDocumentTemplateCodeVersionUniqueConstraint.ts
+++ b/src/shared/infrastructure/database/migrations/1778095709242-FixDocumentTemplateCodeVersionUniqueConstraint.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableIndex } from "typeorm";
+
+export class FixDocumentTemplateCodeVersionUniqueConstraint1778095709242 implements MigrationInterface {
+  name = 'FixDocumentTemplateCodeVersionUniqueConstraint1778095709242';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('document_templates', 'IDX_4dfa5bb611939517d690b00524');
+    await queryRunner.createIndex('document_templates', new TableIndex({
+      name: 'IDX_document_templates_code_version',
+      columnNames: ['code', 'version'],
+      isUnique: true,
+    }));
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('document_templates', 'IDX_document_templates_code_version');
+    await queryRunner.createIndex('document_templates', new TableIndex({
+      name: 'IDX_4dfa5bb611939517d690b00524',
+      columnNames: ['code'],
+      isUnique: true,
+    }));
+  }
+}

--- a/src/shared/infrastructure/database/seeds/initial-seeds.ts
+++ b/src/shared/infrastructure/database/seeds/initial-seeds.ts
@@ -15,6 +15,7 @@ const adminSections = [
   'company',
   'contract',
   'document-model',
+  'document-template',
   'document-type',
   'document',
   'family',

--- a/src/shared/infrastructure/repositories/typeorm-document-field-value.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document-field-value.repository.ts
@@ -1,0 +1,37 @@
+import { Repository } from 'typeorm';
+import { DocumentFieldValueRepository } from '@domains/document/repositories/document-field-value.repository';
+import { DocumentFieldValue } from '@domains/document/entities/document.entity';
+import { DocumentFieldValueEntity } from '../database/entities/document-field-value.entity';
+import { AppDataSource } from '../database/typeorm.config';
+
+export class TypeOrmDocumentFieldValueRepository implements DocumentFieldValueRepository {
+  private repository: Repository<DocumentFieldValueEntity>;
+
+  constructor() {
+    this.repository = AppDataSource.getRepository(DocumentFieldValueEntity);
+  }
+
+  async saveMany(documentId: string, fieldValues: DocumentFieldValue[]): Promise<void> {
+    if (fieldValues.length === 0) return;
+
+    const entities = fieldValues.map(fv => {
+      const entity = this.repository.create({
+        documentId,
+        fieldName: fv.fieldName,
+        fieldValue: fv.fieldValue ?? undefined,
+      });
+      return entity;
+    });
+
+    await this.repository.save(entities);
+  }
+
+  async findByDocumentId(documentId: string): Promise<DocumentFieldValue[]> {
+    const entities = await this.repository.find({ where: { documentId } });
+    return entities.map(e => ({ fieldName: e.fieldName, fieldValue: e.fieldValue ?? null }));
+  }
+
+  async deleteByDocumentId(documentId: string): Promise<void> {
+    await this.repository.delete({ documentId });
+  }
+}

--- a/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
@@ -1,0 +1,123 @@
+import { IsNull, Repository } from 'typeorm';
+import { IDocumentTemplateRepository } from '@domains/document-template/repositories/document-template.repository.interface';
+import { DocumentTemplate, DocumentTemplateField } from '@domains/document-template/entities/document-template.entity';
+import { DocumentTemplateEntity } from '../database/entities/document-template.entity';
+import { AppDataSource } from '../database/typeorm.config';
+import { NotFoundError } from '@shared/domain/errors';
+
+export class TypeOrmDocumentTemplateRepository implements IDocumentTemplateRepository {
+  private repository: Repository<DocumentTemplateEntity>;
+
+  constructor() {
+    this.repository = AppDataSource.getRepository(DocumentTemplateEntity);
+  }
+
+  async save(template: DocumentTemplate): Promise<DocumentTemplate> {
+    const entity = this.toEntity(template);
+    const saved = await this.repository.save(entity);
+    return this.toDomain(saved);
+  }
+
+  async findById(id: string): Promise<DocumentTemplate | null> {
+    const entity = await this.repository.findOne({
+      where: { id, deletedAt: IsNull() },
+    });
+    if (!entity) return null;
+    return this.toDomain(entity);
+  }
+
+  async findAll(groupId?: number): Promise<DocumentTemplate[]> {
+    const where: Record<string, unknown> = { deletedAt: IsNull() };
+    if (groupId) where.groupId = groupId;
+
+    const entities = await this.repository.find({
+      where,
+      order: { code: 'ASC', version: 'DESC' },
+    });
+    return entities.map(e => this.toDomain(e));
+  }
+
+  async findByCode(code: string): Promise<DocumentTemplate[]> {
+    const entities = await this.repository.find({
+      where: { code, deletedAt: IsNull() },
+      order: { version: 'DESC' },
+    });
+    return entities.map(e => this.toDomain(e));
+  }
+
+  async findLatestByCode(code: string, groupId: number): Promise<DocumentTemplate | null> {
+    const entity = await this.repository.findOne({
+      where: { code, groupId, deletedAt: IsNull() },
+      order: { version: 'DESC' },
+    });
+    if (!entity) return null;
+    return this.toDomain(entity);
+  }
+
+  async delete(id: string): Promise<void> {
+    const entity = await this.repository.findOne({ where: { id } });
+    if (!entity) throw new NotFoundError('Plantilla de documento no encontrada');
+    await this.repository.softDelete(id);
+  }
+
+  async getNextCode(): Promise<string> {
+    const result = await this.repository
+      .createQueryBuilder('dt')
+      .select('MAX(dt.code)', 'maxCode')
+      .getRawOne<{ maxCode: string | null }>();
+
+    const maxCode = result?.maxCode;
+    let nextNum = 1;
+
+    if (maxCode) {
+      const match = maxCode.match(/^DOC-(\d+)$/);
+      if (match) {
+        nextNum = parseInt(match[1], 10) + 1;
+      }
+    }
+
+    return `DOC-${String(nextNum).padStart(5, '0')}`;
+  }
+
+  private toEntity(domain: DocumentTemplate): DocumentTemplateEntity {
+    const entity = new DocumentTemplateEntity();
+    entity.id = domain.id;
+    entity.code = domain.code;
+    entity.title = domain.title;
+    entity.version = domain.version;
+    entity.documentDate = domain.documentDate;
+    entity.description = domain.description ?? undefined;
+    entity.fileUrl = domain.fileUrl ?? undefined;
+    entity.groupId = domain.groupId;
+    entity.fieldsJson = domain.fields.length > 0 ? JSON.stringify(domain.fields) : undefined;
+    entity.createdBy = domain.createdBy ?? undefined;
+    return entity;
+  }
+
+  private toDomain(entity: DocumentTemplateEntity): DocumentTemplate {
+    let fields: DocumentTemplateField[] = [];
+    if (entity.fieldsJson) {
+      try {
+        fields = JSON.parse(entity.fieldsJson) as DocumentTemplateField[];
+      } catch {
+        fields = [];
+      }
+    }
+
+    return DocumentTemplate.create({
+      id: entity.id,
+      code: entity.code,
+      title: entity.title,
+      version: entity.version,
+      documentDate: entity.documentDate,
+      description: entity.description,
+      fileUrl: entity.fileUrl,
+      groupId: entity.groupId,
+      fields,
+      createdBy: entity.createdBy,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+      deletedAt: entity.deletedAt ?? null,
+    });
+  }
+}

--- a/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
@@ -3,7 +3,7 @@ import { IDocumentTemplateRepository } from '@domains/document-template/reposito
 import { DocumentTemplate, DocumentTemplateField } from '@domains/document-template/entities/document-template.entity';
 import { DocumentTemplateEntity } from '../database/entities/document-template.entity';
 import { AppDataSource } from '../database/typeorm.config';
-import { NotFoundError } from '@shared/domain/errors';
+import { NotFoundError, ServerError } from '@shared/domain/errors';
 
 export class TypeOrmDocumentTemplateRepository implements IDocumentTemplateRepository {
   private repository: Repository<DocumentTemplateEntity>;
@@ -99,8 +99,8 @@ export class TypeOrmDocumentTemplateRepository implements IDocumentTemplateRepos
     if (entity.fieldsJson) {
       try {
         fields = JSON.parse(entity.fieldsJson) as DocumentTemplateField[];
-      } catch {
-        fields = [];
+      } catch (error) {
+        throw new ServerError(`fieldsJson corrupto para plantilla ${entity.id}: ${(error as Error).message}`);
       }
     }
 

--- a/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document-template.repository.ts
@@ -27,13 +27,26 @@ export class TypeOrmDocumentTemplateRepository implements IDocumentTemplateRepos
   }
 
   async findAll(groupId?: number): Promise<DocumentTemplate[]> {
-    const where: Record<string, unknown> = { deletedAt: IsNull() };
-    if (groupId) where.groupId = groupId;
+    const qb = this.repository
+      .createQueryBuilder('dt')
+      .innerJoin(
+        qb2 => qb2
+          .select('sub.code', 'code')
+          .addSelect('MAX(sub.version)', 'maxVersion')
+          .from(DocumentTemplateEntity, 'sub')
+          .where('sub.deleted_at IS NULL')
+          .groupBy('sub.code'),
+        'latest',
+        'latest.code = dt.code AND latest.maxVersion = dt.version',
+      )
+      .where('dt.deletedAt IS NULL')
+      .orderBy('dt.code', 'ASC');
 
-    const entities = await this.repository.find({
-      where,
-      order: { code: 'ASC', version: 'DESC' },
-    });
+    if (groupId) {
+      qb.andWhere('dt.groupId = :groupId', { groupId });
+    }
+
+    const entities = await qb.getMany();
     return entities.map(e => this.toDomain(e));
   }
 

--- a/src/shared/infrastructure/repositories/typeorm-document.repository.ts
+++ b/src/shared/infrastructure/repositories/typeorm-document.repository.ts
@@ -295,6 +295,7 @@ export class TypeOrmDocumentRepository implements DocumentRepository {
       createdBy: entity.createdBy,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
+      templateId: entity.templateId,
 
       // Populate read-only props from Model
       documentTypeId: entity.documentModel?.documentType?.id,
@@ -325,6 +326,7 @@ export class TypeOrmDocumentRepository implements DocumentRepository {
       createdBy: document.createdBy || undefined,
       createdAt: document.createdAt,
       updatedAt: document.updatedAt,
+      templateId: document.templateId || undefined,
     };
   }
 }


### PR DESCRIPTION
-Se introdujo la entidad DocumentTemplate y su repositorio para gestionar plantillas de documentos.
-Se añadieron los casos de uso de CRUD para las plantillas de documentos.
-Se implementó la entidad DocumentFieldValue y su repositorio para manejar valores dinámicos de campos en documentos.
-Se actualizó la entidad Document para incluir las propiedades templateId y fieldValues.
-Se mejoraron los casos de uso CreateDocument y UpdateDocument para soportar templateId y fieldValues.
-Se crearon esquemas de validación para las plantillas de documentos y sus versiones.
-Se agregaron rutas y métodos de controlador para la gestión de plantillas de documentos.
-Se implementaron migraciones de base de datos para nuevas tablas y relaciones.